### PR TITLE
Solver cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 project(
     Pies

--- a/Include/Pies/Constraints.h
+++ b/Include/Pies/Constraints.h
@@ -28,15 +28,19 @@ protected:
   // The constant matrix B.
   // Matrix<NodeCount, NodeCount> _B;
 
-  // A list of nodes involved in this constraint.
-  std::array<Node*, NodeCount> _nodes;
-
   // The auxiliary variable containing projected node configurations.
   std::array<glm::vec3, NodeCount> _projectedConfig;
 
   TProjection _projection;
 
 public:
+  // TODO: rethink constraints owning Node pointers... global node list may
+  // reallocate between frames. _nodes is currently public to fixup the node
+  // list on reallocation - it is a dirty hack and should be removed soon.
+
+  // A list of nodes involved in this constraint.
+  std::array<Node*, NodeCount> _nodes;
+
   Constraint(
       uint32_t id,
       float w,

--- a/Include/Pies/Node.h
+++ b/Include/Pies/Node.h
@@ -12,6 +12,7 @@ struct Node {
   uint32_t id = 0;
 
   glm::vec3 position{};
+  glm::vec3 prevPosition{};
   glm::vec3 velocity{};
   float mass = 1.0f;
 };

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -7,34 +7,53 @@
 #include <vector>
 
 namespace Pies {
+struct SolverOptions {
+  uint32_t iterations = 4;
+  uint32_t timeSubsteps = 10;
+  float fixedTimestepSize = 0.05f;
+  float gravity = 10.0f;
+  float damping = 0.001f;
+  float friction = 0.1f;
+};
+
 class Solver {
 public:
+  struct Vertex {
+    glm::vec3 position{};
+    glm::vec3 baseColor{};
+    float roughness{};
+    float metallic{};
+  };
+
   bool releaseHinge = false;
 
-  Solver();
+  Solver() = default;
+  Solver(const SolverOptions& options);
+
   void tick(float deltaTime);
 
-  const std::vector<glm::vec3>& getVertices() const { return this->_vertices; }
+  const std::vector<Vertex>& getVertices() const { return this->_vertices; }
 
-  const std::vector<uint32_t>& getDistanceConstraintLines() const {
-    return this->_distanceConstraintLines;
-  }
+  const std::vector<uint32_t>& getLines() const { return this->_lines; }
 
-  const std::vector<uint32_t>& getTriangles() const {
-    return this->_triangles;
-  }
+  const std::vector<uint32_t>& getTriangles() const { return this->_triangles; }
+
+  const SolverOptions& getOptions() const { return this->_options; }
+
+  // Utilities for spawning primitives
+  void createBox(const glm::vec3& translation, float scale, float k);
 
 private:
+  SolverOptions _options;
+  uint32_t _constraintId = 0;
+
   std::vector<Node> _nodes;
   std::vector<PositionConstraint> _positionConstraints;
   std::vector<DistanceConstraint> _distanceConstraints;
 
+  // TODO: Seperate into individual buffers for each object??
   std::vector<uint32_t> _triangles;
-
-  // Scratch vertices vector to avoid reallocation
-  std::vector<glm::vec3> _vertices;
-
-  // Indices for lines representing the distance constraints.
-  std::vector<uint32_t> _distanceConstraintLines;
+  std::vector<uint32_t> _lines;
+  std::vector<Vertex> _vertices;
 };
 } // namespace Pies

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -25,6 +25,7 @@ public:
     float metallic{};
   };
 
+  bool renderStateDirty = true;
   bool releaseHinge = false;
 
   Solver() = default;

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -2,9 +2,13 @@
 
 namespace Pies {
 void DistanceConstraintProjection::operator()(
-    const std::array<Node*, 2>& nodes,
+    const std::vector<Node>& nodes,
+    const std::array<uint32_t, 2>& nodeIds,
     std::array<glm::vec3, 2>& projected) const {
-  glm::vec3 diff = nodes[1]->position - nodes[0]->position;
+  const Node& a = nodes[nodeIds[0]];
+  const Node& b = nodes[nodeIds[1]];
+
+  glm::vec3 diff = b.position - a.position;
   float dist = glm::length(diff);
 
   glm::vec3 dir(1.0f, 0.0f, 0.0f);
@@ -13,27 +17,29 @@ void DistanceConstraintProjection::operator()(
   }
 
   float disp = this->targetDistance - dist;
-  float massSum = nodes[0]->mass + nodes[1]->mass;
+  float massSum = a.mass + b.mass;
 
-  projected[0] = nodes[0]->position - disp * dir * nodes[0]->mass / massSum;
-  projected[1] = nodes[1]->position + disp * dir * nodes[1]->mass / massSum;
+  projected[0] = a.position - disp * dir * a.mass / massSum;
+  projected[1] = b.position + disp * dir * b.mass / massSum;
 }
 
-DistanceConstraint createDistanceConstraint(uint32_t id, Node* a, Node* b) {
+DistanceConstraint
+createDistanceConstraint(uint32_t id, const Node& a, const Node& b) {
   return DistanceConstraint(
       id,
       1.0f,
-      {glm::length(b->position - a->position)},
-      {a, b});
+      {glm::length(b.position - a.position)},
+      {a.id, b.id});
 }
 
 void PositionConstraintProjection::operator()(
-    const std::array<Node*, 1>& nodes,
+    const std::vector<Node>& nodes,
+    const std::array<uint32_t, 1>& nodeIds,
     std::array<glm::vec3, 1>& projected) const {
   projected[0] = this->fixedPosition;
 }
 
-PositionConstraint createPositionConstraint(uint32_t id, Node* node) {
-  return PositionConstraint(id, 1.0f, {node->position}, {node});
+PositionConstraint createPositionConstraint(uint32_t id, const Node& node) {
+  return PositionConstraint(id, 1.0f, {node.position}, {node.id});
 }
 } // namespace Pies

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -1,8 +1,18 @@
 #include "Node.h"
 #include "Solver.h"
 
+#include <cstdlib>
+
 namespace Pies {
 namespace {
+float randf() {
+  return static_cast<float>(double(std::rand()) / RAND_MAX);
+}
+
+glm::vec3 randColor() {
+  return glm::vec3(randf(), randf(), randf());
+}
+
 struct GridId {
   uint32_t x;
   uint32_t y;
@@ -44,11 +54,11 @@ void Solver::createBox(const glm::vec3& translation, float scale, float k) {
   for (uint32_t i = 0; i < grid.width; ++i) {
     for (uint32_t j = 0; j < grid.height; ++j) {
       for (uint32_t k = 0; k < grid.depth; ++k) {
-        uint32_t nodeId = gridIdToNodeId({i, j, k});
+        uint32_t nodeId = grid.gridIdToNodeId({i, j, k});
 
         Node& node = this->_nodes.emplace_back();
         node.id = nodeId;
-        node.position = scale * glm::vec3(i, j, k) + posOffs;
+        node.position = scale * glm::vec3(i, j, k) + translation;
         node.velocity = glm::vec3(0.0f);
         node.mass = 1.0f;
 
@@ -67,14 +77,14 @@ void Solver::createBox(const glm::vec3& translation, float scale, float k) {
   for (uint32_t i = 0; i < grid.width; ++i) {
     for (uint32_t j = 0; j < grid.height; ++j) {
       for (uint32_t k = 0; k < grid.depth; ++k) {
-        uint32_t node000 = gridIdToNodeId({i, j, k});
-        uint32_t node001 = gridIdToNodeId({i, j, k + 1});
-        uint32_t node010 = gridIdToNodeId({i, j + 1, k});
-        uint32_t node011 = gridIdToNodeId({i, j + 1, k + 1});
-        uint32_t node100 = gridIdToNodeId({i + 1, j, k});
-        uint32_t node101 = gridIdToNodeId({i + 1, j, k + 1});
-        uint32_t node110 = gridIdToNodeId({i + 1, j + 1, k});
-        uint32_t node111 = gridIdToNodeId({i + 1, j + 1, k + 1});
+        uint32_t node000 = grid.gridIdToNodeId({i, j, k});
+        uint32_t node001 = grid.gridIdToNodeId({i, j, k + 1});
+        uint32_t node010 = grid.gridIdToNodeId({i, j + 1, k});
+        uint32_t node011 = grid.gridIdToNodeId({i, j + 1, k + 1});
+        uint32_t node100 = grid.gridIdToNodeId({i + 1, j, k});
+        uint32_t node101 = grid.gridIdToNodeId({i + 1, j, k + 1});
+        uint32_t node110 = grid.gridIdToNodeId({i + 1, j + 1, k});
+        uint32_t node111 = grid.gridIdToNodeId({i + 1, j + 1, k + 1});
 
         // Grid-aligned constraints
         if (i < (grid.width - 1)) {
@@ -129,67 +139,67 @@ void Solver::createBox(const glm::vec3& translation, float scale, float k) {
            2 * grid.height * grid.depth));
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
-      this->_triangles.push_back(gridIdToNodeId({i, j, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j + 1, 0}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, j, 0}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, j, 0}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, j + 1, 0}));
 
-      this->_triangles.push_back(gridIdToNodeId({i, j, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j + 1, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i, j + 1, 0}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, j, 0}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, j + 1, 0}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, j + 1, 0}));
 
-      this->_triangles.push_back(gridIdToNodeId({i, j, grid.depth - 1}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j, grid.depth - 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, j, grid.depth - 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, j, grid.depth - 1}));
       this->_triangles.push_back(
-          gridIdToNodeId({i + 1, j + 1, grid.depth - 1}));
+          grid.gridIdToNodeId({i + 1, j + 1, grid.depth - 1}));
 
-      this->_triangles.push_back(gridIdToNodeId({i, j, grid.depth - 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, j, grid.depth - 1}));
       this->_triangles.push_back(
-          gridIdToNodeId({i + 1, j + 1, grid.depth - 1}));
-      this->_triangles.push_back(gridIdToNodeId({i, j + 1, grid.depth - 1}));
+          grid.gridIdToNodeId({i + 1, j + 1, grid.depth - 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, j + 1, grid.depth - 1}));
     }
   }
 
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
-      this->_triangles.push_back(gridIdToNodeId({i, 0, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, 0, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, 0, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, 0, k + 1}));
 
-      this->_triangles.push_back(gridIdToNodeId({i, 0, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({i, 0, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, 0, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, 0, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, 0, k + 1}));
 
-      this->_triangles.push_back(gridIdToNodeId({i, grid.height - 1, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, grid.height - 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, grid.height - 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i + 1, grid.height - 1, k}));
       this->_triangles.push_back(
-          gridIdToNodeId({i + 1, grid.height - 1, k + 1}));
+          grid.gridIdToNodeId({i + 1, grid.height - 1, k + 1}));
 
-      this->_triangles.push_back(gridIdToNodeId({i, grid.height - 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, grid.height - 1, k}));
       this->_triangles.push_back(
-          gridIdToNodeId({i + 1, grid.height - 1, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({i, grid.height - 1, k + 1}));
+          grid.gridIdToNodeId({i + 1, grid.height - 1, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({i, grid.height - 1, k + 1}));
     }
   }
 
   for (uint32_t j = 0; j < grid.height - 1; ++j) {
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
-      this->_triangles.push_back(gridIdToNodeId({0, j, k}));
-      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k}));
-      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({0, j, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({0, j + 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({0, j + 1, k + 1}));
 
-      this->_triangles.push_back(gridIdToNodeId({0, j, k}));
-      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({0, j, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({0, j, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({0, j + 1, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({0, j, k + 1}));
 
-      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j, k}));
-      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j + 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({grid.width - 1, j, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({grid.width - 1, j + 1, k}));
       this->_triangles.push_back(
-          gridIdToNodeId({grid.width - 1, j + 1, k + 1}));
+          grid.gridIdToNodeId({grid.width - 1, j + 1, k + 1}));
 
-      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId({grid.width - 1, j, k}));
       this->_triangles.push_back(
-          gridIdToNodeId({grid.width - 1, j + 1, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j, k + 1}));
+          grid.gridIdToNodeId({grid.width - 1, j + 1, k + 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId({grid.width - 1, j, k + 1}));
     }
   }
 
@@ -200,21 +210,23 @@ void Solver::createBox(const glm::vec3& translation, float scale, float k) {
         1.0f - powf(1.0f - k, 1.0f / this->_options.iterations));
   }
 
-  this->_lines.resize(
+  this->_lines.reserve(
       currentLinesCount +
       2 * (this->_distanceConstraints.size() - currentDistConstraintsCount));
   for (size_t i = currentDistConstraintsCount;
        i < this->_distanceConstraints.size();
        ++i) {
     const DistanceConstraint& constraint = this->_distanceConstraints[i];
-    this->_distanceConstraintLines[2 * i] = constraint.getNode(0).id;
-    this->_distanceConstraintLines[2 * i + 1] = constraint.getNode(1).id;
+    this->_lines.push_back(constraint.getNode(0).id);
+    this->_lines.push_back(constraint.getNode(1).id);
   }
 
   this->_vertices.resize(this->_nodes.size());
   for (uint32_t i = currentNodeCount; i < this->_nodes.size(); ++i) {
     this->_vertices[i].position = this->_nodes[i].position;
-    this->_
+    this->_vertices[i].baseColor = randColor();
+    this->_vertices[i].roughness = randf();
+    this->_vertices[i].metallic = randf();
   }
 }
 } // namespace Pies

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -1,0 +1,220 @@
+#include "Node.h"
+#include "Solver.h"
+
+namespace Pies {
+namespace {
+struct GridId {
+  uint32_t x;
+  uint32_t y;
+  uint32_t z;
+};
+
+struct Grid {
+  uint32_t width;
+  uint32_t height;
+  uint32_t depth;
+
+  GridId nodeIdToGridId(uint32_t nodeId) {
+    GridId gridId;
+
+    gridId.z = nodeId % width;
+    gridId.y = (nodeId / depth) % height;
+    gridId.x = (nodeId / depth) / height;
+
+    return gridId;
+  }
+
+  uint32_t gridIdToNodeId(const GridId& gridId) {
+    return gridId.z + depth * (gridId.y + height * gridId.x);
+  }
+};
+} // namespace
+
+void Solver::createBox(const glm::vec3& translation, float scale, float k) {
+  Grid grid{10, 10, 10};
+
+  size_t currentNodeCount = this->_nodes.size();
+  size_t currentDistConstraintsCount = this->_distanceConstraints.size();
+  size_t currentLinesCount = this->_lines.size();
+  size_t currentTriCount = this->_triangles.size();
+
+  // Add nodes in a grid
+  this->_nodes.reserve(
+      currentNodeCount + grid.width * grid.height * grid.depth);
+  for (uint32_t i = 0; i < grid.width; ++i) {
+    for (uint32_t j = 0; j < grid.height; ++j) {
+      for (uint32_t k = 0; k < grid.depth; ++k) {
+        uint32_t nodeId = gridIdToNodeId({i, j, k});
+
+        Node& node = this->_nodes.emplace_back();
+        node.id = nodeId;
+        node.position = scale * glm::vec3(i, j, k) + posOffs;
+        node.velocity = glm::vec3(0.0f);
+        node.mass = 1.0f;
+
+        // if (i == 0 && j == 0) {
+        //   this->_positionConstraints.push_back(
+        //       createPositionConstraint(this->_constraintId++, &node));
+        // }
+      }
+    }
+  }
+
+  // Add distance constraints in each grid cell
+  this->_distanceConstraints.reserve(
+      currentDistConstraintsCount +
+      8 * (grid.width - 1) * (grid.height - 1) * (grid.depth - 1));
+  for (uint32_t i = 0; i < grid.width; ++i) {
+    for (uint32_t j = 0; j < grid.height; ++j) {
+      for (uint32_t k = 0; k < grid.depth; ++k) {
+        uint32_t node000 = gridIdToNodeId({i, j, k});
+        uint32_t node001 = gridIdToNodeId({i, j, k + 1});
+        uint32_t node010 = gridIdToNodeId({i, j + 1, k});
+        uint32_t node011 = gridIdToNodeId({i, j + 1, k + 1});
+        uint32_t node100 = gridIdToNodeId({i + 1, j, k});
+        uint32_t node101 = gridIdToNodeId({i + 1, j, k + 1});
+        uint32_t node110 = gridIdToNodeId({i + 1, j + 1, k});
+        uint32_t node111 = gridIdToNodeId({i + 1, j + 1, k + 1});
+
+        // Grid-aligned constraints
+        if (i < (grid.width - 1)) {
+          this->_distanceConstraints.push_back(createDistanceConstraint(
+              this->_constraintId++,
+              &this->_nodes[node000],
+              &this->_nodes[node100]));
+        }
+
+        if (j < (grid.height - 1)) {
+          this->_distanceConstraints.push_back(createDistanceConstraint(
+              this->_constraintId++,
+              &this->_nodes[node000],
+              &this->_nodes[node010]));
+        }
+
+        if (k < (grid.depth - 1)) {
+          this->_distanceConstraints.push_back(createDistanceConstraint(
+              this->_constraintId++,
+              &this->_nodes[node000],
+              &this->_nodes[node001]));
+        }
+
+        // Long diagonal constraints
+        if (i < (grid.width - 1) && j < (grid.height - 1) &&
+            k < (grid.depth - 1)) {
+          this->_distanceConstraints.push_back(createDistanceConstraint(
+              this->_constraintId++,
+              &this->_nodes[node000],
+              &this->_nodes[node111]));
+          this->_distanceConstraints.push_back(createDistanceConstraint(
+              this->_constraintId++,
+              &this->_nodes[node100],
+              &this->_nodes[node011]));
+          this->_distanceConstraints.push_back(createDistanceConstraint(
+              this->_constraintId++,
+              &this->_nodes[node010],
+              &this->_nodes[node101]));
+          this->_distanceConstraints.push_back(createDistanceConstraint(
+              this->_constraintId++,
+              &this->_nodes[node001],
+              &this->_nodes[node110]));
+        }
+      }
+    }
+  }
+
+  this->_triangles.reserve(
+      currentTriCount +
+      3 * 2 *
+          (2 * grid.width * grid.height + 2 * grid.width * grid.depth +
+           2 * grid.height * grid.depth));
+  for (uint32_t i = 0; i < grid.width - 1; ++i) {
+    for (uint32_t j = 0; j < grid.height - 1; ++j) {
+      this->_triangles.push_back(gridIdToNodeId({i, j, 0}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, j, 0}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, j + 1, 0}));
+
+      this->_triangles.push_back(gridIdToNodeId({i, j, 0}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, j + 1, 0}));
+      this->_triangles.push_back(gridIdToNodeId({i, j + 1, 0}));
+
+      this->_triangles.push_back(gridIdToNodeId({i, j, grid.depth - 1}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, j, grid.depth - 1}));
+      this->_triangles.push_back(
+          gridIdToNodeId({i + 1, j + 1, grid.depth - 1}));
+
+      this->_triangles.push_back(gridIdToNodeId({i, j, grid.depth - 1}));
+      this->_triangles.push_back(
+          gridIdToNodeId({i + 1, j + 1, grid.depth - 1}));
+      this->_triangles.push_back(gridIdToNodeId({i, j + 1, grid.depth - 1}));
+    }
+  }
+
+  for (uint32_t i = 0; i < grid.width - 1; ++i) {
+    for (uint32_t k = 0; k < grid.depth - 1; ++k) {
+      this->_triangles.push_back(gridIdToNodeId({i, 0, k}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k + 1}));
+
+      this->_triangles.push_back(gridIdToNodeId({i, 0, k}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k + 1}));
+      this->_triangles.push_back(gridIdToNodeId({i, 0, k + 1}));
+
+      this->_triangles.push_back(gridIdToNodeId({i, grid.height - 1, k}));
+      this->_triangles.push_back(gridIdToNodeId({i + 1, grid.height - 1, k}));
+      this->_triangles.push_back(
+          gridIdToNodeId({i + 1, grid.height - 1, k + 1}));
+
+      this->_triangles.push_back(gridIdToNodeId({i, grid.height - 1, k}));
+      this->_triangles.push_back(
+          gridIdToNodeId({i + 1, grid.height - 1, k + 1}));
+      this->_triangles.push_back(gridIdToNodeId({i, grid.height - 1, k + 1}));
+    }
+  }
+
+  for (uint32_t j = 0; j < grid.height - 1; ++j) {
+    for (uint32_t k = 0; k < grid.depth - 1; ++k) {
+      this->_triangles.push_back(gridIdToNodeId({0, j, k}));
+      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k}));
+      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k + 1}));
+
+      this->_triangles.push_back(gridIdToNodeId({0, j, k}));
+      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k + 1}));
+      this->_triangles.push_back(gridIdToNodeId({0, j, k + 1}));
+
+      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j, k}));
+      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j + 1, k}));
+      this->_triangles.push_back(
+          gridIdToNodeId({grid.width - 1, j + 1, k + 1}));
+
+      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j, k}));
+      this->_triangles.push_back(
+          gridIdToNodeId({grid.width - 1, j + 1, k + 1}));
+      this->_triangles.push_back(gridIdToNodeId({grid.width - 1, j, k + 1}));
+    }
+  }
+
+  for (size_t i = currentDistConstraintsCount;
+       i < this->_distanceConstraints.size();
+       ++i) {
+    this->_distanceConstraints[i].setWeight(
+        1.0f - powf(1.0f - k, 1.0f / this->_options.iterations));
+  }
+
+  this->_lines.resize(
+      currentLinesCount +
+      2 * (this->_distanceConstraints.size() - currentDistConstraintsCount));
+  for (size_t i = currentDistConstraintsCount;
+       i < this->_distanceConstraints.size();
+       ++i) {
+    const DistanceConstraint& constraint = this->_distanceConstraints[i];
+    this->_distanceConstraintLines[2 * i] = constraint.getNode(0).id;
+    this->_distanceConstraintLines[2 * i + 1] = constraint.getNode(1).id;
+  }
+
+  this->_vertices.resize(this->_nodes.size());
+  for (uint32_t i = currentNodeCount; i < this->_nodes.size(); ++i) {
+    this->_vertices[i].position = this->_nodes[i].position;
+    this->_
+  }
+}
+} // namespace Pies

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -4,14 +4,6 @@
 #define GRID_HEIGHT 10
 #define GRID_DEPTH 10
 
-#define GRAVITY 10.0f
-
-#define DAMPING 0.001f
-#define FRICTION 0.1f
-
-#define SOLVER_ITERS 4
-#define SOLVER_SUBSTEPS 10
-
 namespace Pies {
 namespace {
 struct GridId {
@@ -35,194 +27,23 @@ uint32_t gridIdToNodeId(const GridId& gridId) {
 }
 } // namespace
 
-Solver::Solver() {
-  glm::vec3 posOffs = glm::vec3(-10.0f, 5.0f, 0.0f);
-  float scale = 0.5f;
-
-  uint32_t constraintId = 0;
-
-  // Add nodes in a grid
-  this->_nodes.reserve(GRID_WIDTH * GRID_HEIGHT * GRID_DEPTH);
-  for (uint32_t i = 0; i < GRID_WIDTH; ++i) {
-    for (uint32_t j = 0; j < GRID_HEIGHT; ++j) {
-      for (uint32_t k = 0; k < GRID_DEPTH; ++k) {
-        uint32_t nodeId = gridIdToNodeId({i, j, k});
-
-        Node& node = this->_nodes.emplace_back();
-        node.id = nodeId;
-        node.position = scale * glm::vec3(i, j, k) + posOffs;
-        node.velocity = glm::vec3(0.0f);
-        node.mass = 1.0f;
-
-        if (i == 0 && j == 0) {
-          this->_positionConstraints.push_back(
-              createPositionConstraint(constraintId++, &node));
-        }
-      }
-    }
-  }
-
-  // Add distance constraints in each grid cell
-  this->_distanceConstraints.reserve(
-      8 * (GRID_WIDTH - 1) * (GRID_HEIGHT - 1) * (GRID_DEPTH - 1));
-  for (uint32_t i = 0; i < GRID_WIDTH; ++i) {
-    for (uint32_t j = 0; j < GRID_HEIGHT; ++j) {
-      for (uint32_t k = 0; k < GRID_DEPTH; ++k) {
-        uint32_t node000 = gridIdToNodeId({i, j, k});
-        uint32_t node001 = gridIdToNodeId({i, j, k + 1});
-        uint32_t node010 = gridIdToNodeId({i, j + 1, k});
-        uint32_t node011 = gridIdToNodeId({i, j + 1, k + 1});
-        uint32_t node100 = gridIdToNodeId({i + 1, j, k});
-        uint32_t node101 = gridIdToNodeId({i + 1, j, k + 1});
-        uint32_t node110 = gridIdToNodeId({i + 1, j + 1, k});
-        uint32_t node111 = gridIdToNodeId({i + 1, j + 1, k + 1});
-
-        // Grid-aligned constraints
-        if (i < (GRID_WIDTH - 1)) {
-          this->_distanceConstraints.push_back(createDistanceConstraint(
-              constraintId++,
-              &this->_nodes[node000],
-              &this->_nodes[node100]));
-        }
-
-        if (j < (GRID_HEIGHT - 1)) {
-          this->_distanceConstraints.push_back(createDistanceConstraint(
-              constraintId++,
-              &this->_nodes[node000],
-              &this->_nodes[node010]));
-        }
-
-        if (k < (GRID_DEPTH - 1)) {
-          this->_distanceConstraints.push_back(createDistanceConstraint(
-              constraintId++,
-              &this->_nodes[node000],
-              &this->_nodes[node001]));
-        }
-
-        // Long diagonal constraints
-        if (i < (GRID_WIDTH - 1) && j < (GRID_HEIGHT - 1) &&
-            k < (GRID_DEPTH - 1)) {
-          this->_distanceConstraints.push_back(createDistanceConstraint(
-              constraintId++,
-              &this->_nodes[node000],
-              &this->_nodes[node111]));
-          this->_distanceConstraints.push_back(createDistanceConstraint(
-              constraintId++,
-              &this->_nodes[node100],
-              &this->_nodes[node011]));
-          this->_distanceConstraints.push_back(createDistanceConstraint(
-              constraintId++,
-              &this->_nodes[node010],
-              &this->_nodes[node101]));
-          this->_distanceConstraints.push_back(createDistanceConstraint(
-              constraintId++,
-              &this->_nodes[node001],
-              &this->_nodes[node110]));
-        }
-      }
-    }
-  }
-
-  this->_triangles.reserve(
-      3 * 2 *
-      (2 * GRID_WIDTH * GRID_HEIGHT + 2 * GRID_WIDTH * GRID_DEPTH +
-       2 * GRID_HEIGHT * GRID_DEPTH));
-  for (uint32_t i = 0; i < GRID_WIDTH - 1; ++i) {
-    for (uint32_t j = 0; j < GRID_HEIGHT - 1; ++j) {
-      this->_triangles.push_back(gridIdToNodeId({i, j, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j + 1, 0}));
-
-      this->_triangles.push_back(gridIdToNodeId({i, j, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j + 1, 0}));
-      this->_triangles.push_back(gridIdToNodeId({i, j + 1, 0}));
-
-      this->_triangles.push_back(gridIdToNodeId({i, j, GRID_DEPTH - 1}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, j, GRID_DEPTH - 1}));
-      this->_triangles.push_back(
-          gridIdToNodeId({i + 1, j + 1, GRID_DEPTH - 1}));
-
-      this->_triangles.push_back(gridIdToNodeId({i, j, GRID_DEPTH - 1}));
-      this->_triangles.push_back(
-          gridIdToNodeId({i + 1, j + 1, GRID_DEPTH - 1}));
-      this->_triangles.push_back(gridIdToNodeId({i, j + 1, GRID_DEPTH - 1}));
-    }
-  }
-
-  for (uint32_t i = 0; i < GRID_WIDTH - 1; ++i) {
-    for (uint32_t k = 0; k < GRID_DEPTH - 1; ++k) {
-      this->_triangles.push_back(gridIdToNodeId({i, 0, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k + 1}));
-
-      this->_triangles.push_back(gridIdToNodeId({i, 0, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, 0, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({i, 0, k + 1}));
-
-      this->_triangles.push_back(gridIdToNodeId({i, GRID_HEIGHT - 1, k}));
-      this->_triangles.push_back(gridIdToNodeId({i + 1, GRID_HEIGHT - 1, k}));
-      this->_triangles.push_back(
-          gridIdToNodeId({i + 1, GRID_HEIGHT - 1, k + 1}));
-
-      this->_triangles.push_back(gridIdToNodeId({i, GRID_HEIGHT - 1, k}));
-      this->_triangles.push_back(
-          gridIdToNodeId({i + 1, GRID_HEIGHT - 1, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({i, GRID_HEIGHT - 1, k + 1}));
-    }
-  }
-
-  for (uint32_t j = 0; j < GRID_HEIGHT - 1; ++j) {
-    for (uint32_t k = 0; k < GRID_DEPTH - 1; ++k) {
-      this->_triangles.push_back(gridIdToNodeId({0, j, k}));
-      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k}));
-      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k + 1}));
-
-      this->_triangles.push_back(gridIdToNodeId({0, j, k}));
-      this->_triangles.push_back(gridIdToNodeId({0, j + 1, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({0, j, k + 1}));
-
-      this->_triangles.push_back(gridIdToNodeId({GRID_WIDTH - 1, j, k}));
-      this->_triangles.push_back(gridIdToNodeId({GRID_WIDTH - 1, j + 1, k}));
-      this->_triangles.push_back(
-          gridIdToNodeId({GRID_WIDTH - 1, j + 1, k + 1}));
-
-      this->_triangles.push_back(gridIdToNodeId({GRID_WIDTH - 1, j, k}));
-      this->_triangles.push_back(
-          gridIdToNodeId({GRID_WIDTH - 1, j + 1, k + 1}));
-      this->_triangles.push_back(gridIdToNodeId({GRID_WIDTH - 1, j, k + 1}));
-    }
-  }
-
-  for (DistanceConstraint& constraint : this->_distanceConstraints) {
-    float k = 0.85f;
-    constraint.setWeight(1.0f - powf(1.0f - k, 1.0f / SOLVER_ITERS));
-  }
-
-  this->_distanceConstraintLines.resize(2 * this->_distanceConstraints.size());
-  for (size_t i = 0; i < this->_distanceConstraints.size(); ++i) {
-    const DistanceConstraint& constraint = this->_distanceConstraints[i];
-    this->_distanceConstraintLines[2 * i] = constraint.getNode(0).id;
-    this->_distanceConstraintLines[2 * i + 1] = constraint.getNode(1).id;
-  }
-
-  this->_vertices.resize(this->_nodes.size());
-  for (uint32_t i = 0; i < this->_nodes.size(); ++i) {
-    this->_vertices[i] = this->_nodes[i].position;
-  }
+Solver::Solver(const SolverOptions& options) : _options(options) {
+  createBox(glm::vec3(-10.0f, 5.0f, 0.0f), 0.5f, 0.85f);
 }
 
-void Solver::tick(float timestep) {
-  float deltaTime = timestep / SOLVER_SUBSTEPS;
+void Solver::tick(float /*timestep*/) {
+  float deltaTime =
+      this->_options.fixedTimestepSize / this->_options.timeSubsteps;
 
   // Time substeps
-  for (int substep = 0; substep < SOLVER_SUBSTEPS; ++substep) {
+  for (int substep = 0; substep < this->_options.timeSubsteps; ++substep) {
     // Apply external forces and advect nodes
     for (Node& node : this->_nodes) {
-      node.velocity += glm::vec3(0.0f, -GRAVITY, 0.0f) * deltaTime;
-      node.position += node.velocity * deltaTime;
+      node.position += glm::vec3(0.0f, -this->_options.gravity, 0.0f) *
+                       deltaTime * deltaTime;
     }
 
-    for (uint32_t i = 0; i < SOLVER_ITERS; ++i) {
+    for (uint32_t i = 0; i < this->_options.iterations; ++i) {
       if (!releaseHinge) {
         for (PositionConstraint& constraint : this->_positionConstraints) {
           constraint.projectNodePositions();
@@ -232,6 +53,9 @@ void Solver::tick(float timestep) {
       for (DistanceConstraint& constraint : this->_distanceConstraints) {
         constraint.projectNodePositions();
       }
+
+      // TODO: Collision solver
+      // TODO: Apply projections to collision constraints
 
       // Floor constraint
       for (Node& node : this->_nodes) {
@@ -244,12 +68,13 @@ void Solver::tick(float timestep) {
     // Compute new velocity and construct new vertex positions
     for (uint32_t i = 0; i < this->_nodes.size(); ++i) {
       this->_nodes[i].velocity =
-          (1.0f - DAMPING) * (this->_nodes[i].position - this->_vertices[i]) /
-          deltaTime;
+          (1.0f - this->_options.damping) *
+          (this->_nodes[i].position - this->_vertices[i]) / deltaTime;
 
+      // TODO: friction for dynamically generated constraints
       if (this->_nodes[i].position.y <= -8.0f) {
-        this->_nodes[i].velocity.x *= 1.0f - FRICTION;
-        this->_nodes[i].velocity.z *= 1.0f - FRICTION;
+        this->_nodes[i].velocity.x *= 1.0f - this->_options.friction;
+        this->_nodes[i].velocity.z *= 1.0f - this->_options.friction;
       }
 
       this->_vertices[i] = this->_nodes[i].position;

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -2,9 +2,7 @@
 
 namespace Pies {
 
-Solver::Solver(const SolverOptions& options) : _options(options) {
-  createBox(glm::vec3(-10.0f, 5.0f, 0.0f), 0.5f, 0.85f);
-}
+Solver::Solver(const SolverOptions& options) : _options(options) {}
 
 void Solver::tick(float /*timestep*/) {
   float deltaTime =
@@ -15,8 +13,8 @@ void Solver::tick(float /*timestep*/) {
     // Apply external forces and advect nodes
     for (Node& node : this->_nodes) {
       node.prevPosition = node.position;
-      node.position +=
-          node.velocity * deltaTime + glm::vec3(0.0f, -this->_options.gravity, 0.0f) *
+      node.position += node.velocity * deltaTime +
+                       glm::vec3(0.0f, -this->_options.gravity, 0.0f) *
                            deltaTime * deltaTime;
     }
 

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -21,12 +21,12 @@ void Solver::tick(float /*timestep*/) {
     for (uint32_t i = 0; i < this->_options.iterations; ++i) {
       if (!releaseHinge) {
         for (PositionConstraint& constraint : this->_positionConstraints) {
-          constraint.projectNodePositions();
+          constraint.projectNodePositions(this->_nodes);
         }
       }
 
       for (DistanceConstraint& constraint : this->_distanceConstraints) {
-        constraint.projectNodePositions();
+        constraint.projectNodePositions(this->_nodes);
       }
 
       // TODO: Collision solver


### PR DESCRIPTION
Changes:
- Decouples solver logic from hardcoded primitive creation - the primitive creation is primarily intended for testing.
- Redesigns the constraint class to not require Node pointers directly. The previous approach was precarious since Node pointers can be invalidated when the global node vector reallocates.
- Exposes flexible interface for exporting simulation results, in terms of vertices (nodes) and indices (to visualize lines or triangles between nodes). This hooks into PiesForAlthea for rendering.
- Allows primitive creation to be chained one-after-another and also allows primitive creation to happen dynamically (with the concept of a dirty-able render state).