### PR TITLE
Implement dynamic node collisions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "Extern/tetgen"]
 	path = Extern/tetgen
 	url = git@github.com:libigl/tetgen
+[submodule "Extern/parallel-hashmap"]
+	path = Extern/parallel-hashmap
+	url = git@github.com:greg7mdp/parallel-hashmap

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
 
 project(
     Pies
@@ -32,14 +32,17 @@ if (NOT TARGET glm)
 endif()
 
 add_subdirectory(Extern/tetgen)
+add_subdirectory(Extern/parallel-hashmap)
 
 target_include_directories (Pies
     PUBLIC
       Include
       Extern/glm
-      Extern/tetgen)
+      Extern/tetgen
+      Extern/parallel-hashmap)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC glm)
 target_link_libraries(${PROJECT_NAME} PUBLIC tetgen)
+target_link_libraries(${PROJECT_NAME} PUBLIC phmap)
 
 

--- a/Include/Pies/Constraints.h
+++ b/Include/Pies/Constraints.h
@@ -126,7 +126,7 @@ typedef Constraint<1, PositionConstraintProjection> PositionConstraint;
 PositionConstraint createPositionConstraint(uint32_t id, const Node& node);
 
 struct TetrahedralConstraintProjection {
-  float targetVolume;
+  glm::mat3 Qinv;
 
   void operator()(
       const std::vector<Node>& nodes,
@@ -142,6 +142,22 @@ TetrahedralConstraint createTetrahedralConstraint(
     const Node& c,
     const Node& d);
 
+struct VolumeConstraintProjection {
+  float targetVolume;
+
+  void operator()(
+      const std::vector<Node>& nodes,
+      const std::array<uint32_t, 4>& nodeIds,
+      std::array<glm::vec3, 4>& projected) const;
+};
+typedef Constraint<4, VolumeConstraintProjection> VolumeConstraint;
+VolumeConstraint createVolumeConstraint(
+    uint32_t id,
+    float k,
+    const Node& a,
+    const Node& b,
+    const Node& c,
+    const Node& d);
 // struct CollisionConstraintProjection {
 //   glm::vec3 intersection;
 //   glm::vec3 normal;

--- a/Include/Pies/Constraints.h
+++ b/Include/Pies/Constraints.h
@@ -125,6 +125,23 @@ struct PositionConstraintProjection {
 typedef Constraint<1, PositionConstraintProjection> PositionConstraint;
 PositionConstraint createPositionConstraint(uint32_t id, const Node& node);
 
+struct TetrahedralConstraintProjection {
+  float targetVolume;
+
+  void operator()(
+      const std::vector<Node>& nodes,
+      const std::array<uint32_t, 4>& nodeIds,
+      std::array<glm::vec3, 4>& projected) const;
+};
+typedef Constraint<4, TetrahedralConstraintProjection> TetrahedralConstraint;
+TetrahedralConstraint createTetrahedralConstraint(
+    uint32_t id,
+    float k,
+    const Node& a,
+    const Node& b,
+    const Node& c,
+    const Node& d);
+
 // struct CollisionConstraintProjection {
 //   glm::vec3 intersection;
 //   glm::vec3 normal;

--- a/Include/Pies/Node.h
+++ b/Include/Pies/Node.h
@@ -14,6 +14,7 @@ struct Node {
   glm::vec3 position{};
   glm::vec3 prevPosition{};
   glm::vec3 velocity{};
+  float radius = 0.1f;
   float mass = 1.0f;
 };
 } // namespace Pies

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -46,6 +46,8 @@ public:
 
   const SolverOptions& getOptions() const { return this->_options; }
 
+  void clear();
+  
   // Utilities for spawning primitives
   void createBox(const glm::vec3& translation, float scale, float stiffness);
   void createTetBox(

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -16,6 +16,7 @@ struct SolverOptions {
   float gravity = 10.0f;
   float damping = 0.001f;
   float friction = 0.1f;
+  float floorHeight = 0.0f;
 };
 
 class Solver {
@@ -23,7 +24,7 @@ public:
   struct Vertex {
     glm::vec3 position{};
     float radius{};
-    
+
     glm::vec3 baseColor{};
     float roughness{};
     float metallic{};
@@ -47,7 +48,11 @@ public:
 
   // Utilities for spawning primitives
   void createBox(const glm::vec3& translation, float scale, float stiffness);
-  void createTetBox(const glm::vec3& translation, float scale, float stiffness);
+  void createTetBox(
+      const glm::vec3& translation,
+      float scale,
+      const glm::vec3& initialVelocity,
+      float stiffness);
 
 private:
   struct NodeCompRange {

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -3,6 +3,7 @@
 #include "Constraints.h"
 #include "Node.h"
 #include "SpatialHash.h"
+#include "Tetrahedron.h"
 
 #include <cstdint>
 #include <vector>
@@ -21,6 +22,8 @@ class Solver {
 public:
   struct Vertex {
     glm::vec3 position{};
+    float radius{};
+    
     glm::vec3 baseColor{};
     float roughness{};
     float metallic{};
@@ -48,17 +51,25 @@ public:
 
 private:
   struct NodeCompRange {
-    const SpatialHashGrid& grid;
+    SpatialHashGridCellRange
+    operator()(const Node& node, const SpatialHashGrid& grid) const;
+  };
 
-    SpatialHashGridCellRange operator()(const Node& node) const;
+  struct TetCompRange {
+    const std::vector<Node>& nodes;
+
+    SpatialHashGridCellRange
+    operator()(const Tetrahedron& node, const SpatialHashGrid& grid) const;
   };
 
   SolverOptions _options;
   uint32_t _constraintId = 0;
 
   SpatialHash<Node, NodeCompRange> _spatialHashNodes;
+  SpatialHash<Tetrahedron, TetCompRange> _spatialHashTets;
 
   std::vector<Node> _nodes;
+  std::vector<Tetrahedron> _tets;
   std::vector<PositionConstraint> _positionConstraints;
   std::vector<DistanceConstraint> _distanceConstraints;
   std::vector<TetrahedralConstraint> _tetConstraints;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -2,6 +2,7 @@
 
 #include "Constraints.h"
 #include "Node.h"
+#include "SpatialHash.h"
 
 #include <cstdint>
 #include <vector>
@@ -45,8 +46,16 @@ public:
   void createBox(const glm::vec3& translation, float scale, float k);
 
 private:
+  struct NodeCompRange {
+    const SpatialHashGrid& grid;
+
+    SpatialHashGridCellRange operator()(const Node& node) const;
+  };
+
   SolverOptions _options;
   uint32_t _constraintId = 0;
+
+  SpatialHash<Node, NodeCompRange> _spatialHashNodes;
 
   std::vector<Node> _nodes;
   std::vector<PositionConstraint> _positionConstraints;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -43,7 +43,8 @@ public:
   const SolverOptions& getOptions() const { return this->_options; }
 
   // Utilities for spawning primitives
-  void createBox(const glm::vec3& translation, float scale, float k);
+  void createBox(const glm::vec3& translation, float scale, float stiffness);
+  void createTetBox(const glm::vec3& translation, float scale, float stiffness);
 
 private:
   struct NodeCompRange {
@@ -60,6 +61,7 @@ private:
   std::vector<Node> _nodes;
   std::vector<PositionConstraint> _positionConstraints;
   std::vector<DistanceConstraint> _distanceConstraints;
+  std::vector<TetrahedralConstraint> _tetConstraints;
 
   // TODO: Seperate into individual buffers for each object??
   std::vector<uint32_t> _triangles;

--- a/Include/Pies/SpatialHash.h
+++ b/Include/Pies/SpatialHash.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_inverse.hpp>
+#include <math.h>
+#include <parallel_hashmap/phmap.h>
+
+#include <cstdint>
+#include <functional>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace Pies {
+struct SpatialHashGridCellId {
+  int64_t x = 0;
+  int64_t y = 0;
+  int64_t z = 0;
+
+  bool operator==(const SpatialHashGridCellId& rhs) const {
+    return this->x == rhs.x && this->y == rhs.y && this->z == rhs.z;
+  }
+};
+} // namespace Pies
+
+namespace std {
+template <> struct hash<Pies::SpatialHashGridCellId> {
+  size_t operator()(const Pies::SpatialHashGridCellId& id) const noexcept {
+    int64_t hash = (id.x * 92837111) ^ (id.y * 689287499) ^ (id.z * 283923481);
+    return static_cast<size_t>(std::abs(hash));
+  }
+};
+} // namespace std
+
+namespace Pies {
+
+template <typename TValue> struct SpatialHashGridCellBucket {
+  std::vector<TValue*> values;
+};
+
+struct SpatialHashGridCellRange {
+  int64_t minX;
+  int64_t minY;
+  int64_t minZ;
+
+  uint32_t lengthX;
+  uint32_t lengthY;
+  uint32_t lengthZ;
+};
+
+/**
+ * @brief Defined to be a uniform grid such that, in local space, the cell
+ * lengths are 1 and the cells are aligned to the XYZ axes. Transforms between
+ * grid space and world space are provided.
+ */
+struct SpatialHashGrid {
+  glm::mat4 gridToWorld;
+  glm::mat4 worldToGrid;
+};
+
+template <typename TValue, typename TCompRange> class SpatialHash {
+public:
+  SpatialHash(const glm::mat4& transform = glm::mat4(1.0f))
+      : _grid({transform, glm::affineInverse(transform)}) {}
+
+  const glm::mat4& localToWorld() const { return this->_gridTransform; }
+
+  const glm::mat4& worldToLocal() const { return this->_invGridTransform; }
+
+  void parallelBulkInsert(std::vector<TValue>& values) {
+    TCompRange compRangeFn{this->_grid};
+
+    // NOTE: Based on example given in:
+    // https://greg7mdp.github.io/parallel-hashmap/
+    constexpr size_t numThreads = 8; // has to be a power of two
+    std::unique_ptr<std::thread> threads[numThreads];
+    auto threadFn = [&hash = this->_hashMap, &values, &compRangeFn, numThreads](
+                        size_t thread_idx) {
+      size_t modulo =
+          hash.subcnt() / numThreads; // subcnt() returns the number of submaps
+
+      for (size_t i = 0; i < values.size(); ++i) {
+        TValue& value = values[i];
+        // const GridCellRange& range = gridCellRanges[i];
+        SpatialHashGridCellRange range = compRangeFn(value);
+
+        for (uint32_t dx = 0; dx < range.lengthX; ++dx) {
+          for (uint32_t dy = 0; dy < range.lengthY; ++dy) {
+            for (uint32_t dz = 0; dz < range.lengthZ; ++dz) {
+              // Compute grid cell id
+              SpatialHashGridCellId id{
+                  range.minX + dx,
+                  range.minY + dy,
+                  range.minZ + dz};
+              // Compute its hash
+              size_t hashVal = hash.hash(id);
+              // Compute the submap index for this hash
+              size_t idx = hash.subidx(hashVal);
+              if (idx / modulo == thread_idx) {
+                // If the submap is suitable for this thread, add the value to
+                // the grid cell bucket.
+                auto it = hash.find(id, hashVal);
+                if (it != hash.end()) {
+                  it->second.values.push_back(&value);
+                } else {
+                  hash.emplace_with_hash(
+                      hashVal,
+                      std::make_pair(
+                          id,
+                          SpatialHashGridCellBucket<TValue>{{&value}}));
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    for (size_t i = 0; i < numThreads; ++i) {
+      threads[i].reset(new std::thread(threadFn, i));
+    }
+
+    // wait for the threads to finish their work and exit
+    for (size_t i = 0; i < numThreads; ++i) {
+      threads[i]->join();
+    }
+  }
+
+  void clear() { this->_hashMap.clear(); }
+
+private:
+  SpatialHashGrid _grid;
+  phmap::parallel_flat_hash_map<
+      SpatialHashGridCellId,
+      SpatialHashGridCellBucket<TValue>>
+      _hashMap;
+};
+} // namespace Pies

--- a/Include/Pies/Tetrahedron.h
+++ b/Include/Pies/Tetrahedron.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Pies {
+struct Tetrahedron {
+  uint32_t nodeIds[4];
+};
+} // namespace Pies

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -1,5 +1,9 @@
 #include "Constraints.h"
 
+#include <glm/gtc/matrix_access.hpp>
+#include <glm/gtc/matrix_inverse.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
 namespace Pies {
 void DistanceConstraintProjection::operator()(
     const std::vector<Node>& nodes,
@@ -52,6 +56,81 @@ void TetrahedralConstraintProjection::operator()(
   const Node& x3 = nodes[nodeIds[2]];
   const Node& x4 = nodes[nodeIds[3]];
 
+  glm::mat3 P(
+      x2.position - x1.position,
+      x3.position - x1.position,
+      x4.position - x1.position);
+
+  // Deformation gradient
+  glm::mat3 F = P * this->Qinv;
+  glm::mat3 Ft = glm::transpose(F);
+
+  float stretchResistance = 1.0f;
+  glm::mat3 S = Ft * F;
+
+  // Tensor of stretch and strain constraints
+  // Green - St Vernant strain formulation
+  // TODO: Use sqrt version
+  glm::mat3 C = S - glm::mat3(stretchResistance * stretchResistance);
+
+  projected[0] = x1.position;
+  projected[1] = x2.position;
+  projected[2] = x3.position;
+  projected[3] = x4.position;
+
+  // Project the constraints one after another
+  for (uint32_t i = 0; i < 3; ++i) {
+    for (uint32_t j = 0; j <= i; ++j) {
+      glm::mat3 dCijdX =
+          glm::outerProduct(glm::column(F, j), glm::column(this->Qinv, i)) +
+          glm::outerProduct(glm::column(F, i), glm::column(this->Qinv, j));
+      glm::vec3 dCijdx1 = -glm::column(dCijdX, 0) - glm::column(dCijdX, 1) -
+                          glm::column(dCijdX, 2);
+      float denom =
+          x1.mass * glm::dot(dCijdx1, dCijdx1) +
+          x2.mass * glm::dot(glm::column(dCijdX, 0), glm::column(dCijdX, 0)) +
+          x3.mass * glm::dot(glm::column(dCijdX, 1), glm::column(dCijdX, 1)) +
+          x4.mass * glm::dot(glm::column(dCijdX, 2), glm::column(dCijdX, 2));
+      float lambda = C[i][j] / denom;
+
+      // Recompute F from projected positions?
+      projected[0] += -lambda * x1.mass * dCijdx1;
+      projected[1] += -lambda * x2.mass * glm::column(dCijdX, 0);
+      projected[2] += -lambda * x3.mass * glm::column(dCijdX, 1);
+      projected[3] += -lambda * x4.mass * glm::column(dCijdX, 2);
+    }
+  }
+}
+
+TetrahedralConstraint createTetrahedralConstraint(
+    uint32_t id,
+    float k,
+    const Node& x1,
+    const Node& x2,
+    const Node& x3,
+    const Node& x4) {
+
+  glm::mat3 Q(
+      x2.position - x1.position,
+      x3.position - x1.position,
+      x4.position - x1.position);
+
+  return TetrahedralConstraint(
+      id,
+      k,
+      {glm::inverse(Q)},
+      {x1.id, x2.id, x3.id, x4.id});
+}
+
+void VolumeConstraintProjection::operator()(
+    const std::vector<Node>& nodes,
+    const std::array<uint32_t, 4>& nodeIds,
+    std::array<glm::vec3, 4>& projected) const {
+  const Node& x1 = nodes[nodeIds[0]];
+  const Node& x2 = nodes[nodeIds[1]];
+  const Node& x3 = nodes[nodeIds[2]];
+  const Node& x4 = nodes[nodeIds[3]];
+
   glm::vec3 x21 = x2.position - x1.position;
   glm::vec3 x31 = x3.position - x1.position;
   glm::vec3 x41 = x4.position - x1.position;
@@ -68,13 +147,14 @@ void TetrahedralConstraintProjection::operator()(
   float lambda = -C / dCdX_magsq;
   float massSum = x1.mass + x2.mass + x3.mass + x4.mass;
 
-  projected[0] = x1.position + lambda * dCdx1;// * x1.mass / massSum;
-  projected[1] = x2.position + lambda * dCdx2;// * x2.mass / massSum;
-  projected[2] = x3.position + lambda * dCdx3;// * x3.mass / massSum;
-  projected[3] = x4.position + lambda * dCdx4;// * x4.mass / massSum;
+  // TODO: add in mass / massSum
+  projected[0] = x1.position + lambda * dCdx1; // * x1.mass / massSum;
+  projected[1] = x2.position + lambda * dCdx2; // * x2.mass / massSum;
+  projected[2] = x3.position + lambda * dCdx3; // * x3.mass / massSum;
+  projected[3] = x4.position + lambda * dCdx4; // * x4.mass / massSum;
 }
 
-TetrahedralConstraint createTetrahedralConstraint(
+VolumeConstraint createVolumeConstraint(
     uint32_t id,
     float k,
     const Node& x1,
@@ -86,10 +166,6 @@ TetrahedralConstraint createTetrahedralConstraint(
   glm::vec3 x41 = x4.position - x1.position;
 
   float targetVolume = glm::dot(glm::cross(x21, x31), x41) / 6.0f;
-  return TetrahedralConstraint(
-      id,
-      k,
-      {targetVolume},
-      {x1.id, x2.id, x3.id, x4.id});
+  return VolumeConstraint(id, k, {targetVolume}, {x1.id, x2.id, x3.id, x4.id});
 }
 } // namespace Pies

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -42,4 +42,54 @@ void PositionConstraintProjection::operator()(
 PositionConstraint createPositionConstraint(uint32_t id, const Node& node) {
   return PositionConstraint(id, 1.0f, {node.position}, {node.id});
 }
+
+void TetrahedralConstraintProjection::operator()(
+    const std::vector<Node>& nodes,
+    const std::array<uint32_t, 4>& nodeIds,
+    std::array<glm::vec3, 4>& projected) const {
+  const Node& x1 = nodes[nodeIds[0]];
+  const Node& x2 = nodes[nodeIds[1]];
+  const Node& x3 = nodes[nodeIds[2]];
+  const Node& x4 = nodes[nodeIds[3]];
+
+  glm::vec3 x21 = x2.position - x1.position;
+  glm::vec3 x31 = x3.position - x1.position;
+  glm::vec3 x41 = x4.position - x1.position;
+
+  glm::vec3 dCdx2 = glm::cross(x31, x41) / 6.0f;
+  glm::vec3 dCdx3 = glm::cross(x41, x21) / 6.0f;
+  glm::vec3 dCdx4 = glm::cross(x21, x31) / 6.0f;
+  glm::vec3 dCdx1 = -dCdx2 - dCdx3 - dCdx4;
+
+  float C = glm::dot(dCdx4, x41) - this->targetVolume;
+  float dCdX_magsq = glm::dot(dCdx1, dCdx1) + glm::dot(dCdx2, dCdx2) +
+                     glm::dot(dCdx3, dCdx3) + glm::dot(dCdx4, dCdx4);
+
+  float lambda = -C / dCdX_magsq;
+  float massSum = x1.mass + x2.mass + x3.mass + x4.mass;
+
+  projected[0] = x1.position + lambda * dCdx1;// * x1.mass / massSum;
+  projected[1] = x2.position + lambda * dCdx2;// * x2.mass / massSum;
+  projected[2] = x3.position + lambda * dCdx3;// * x3.mass / massSum;
+  projected[3] = x4.position + lambda * dCdx4;// * x4.mass / massSum;
+}
+
+TetrahedralConstraint createTetrahedralConstraint(
+    uint32_t id,
+    float k,
+    const Node& x1,
+    const Node& x2,
+    const Node& x3,
+    const Node& x4) {
+  glm::vec3 x21 = x2.position - x1.position;
+  glm::vec3 x31 = x3.position - x1.position;
+  glm::vec3 x41 = x4.position - x1.position;
+
+  float targetVolume = glm::dot(glm::cross(x21, x31), x41) / 6.0f;
+  return TetrahedralConstraint(
+      id,
+      k,
+      {targetVolume},
+      {x1.id, x2.id, x3.id, x4.id});
+}
 } // namespace Pies

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -7,7 +7,7 @@ namespace Pies {
 namespace {
 float randf() { return static_cast<float>(double(std::rand()) / RAND_MAX); }
 
-glm::vec3 randColor() { return 255.0f * glm::vec3(randf(), randf(), randf()); }
+glm::vec3 randColor() { return glm::vec3(randf(), randf(), randf()); }
 
 struct GridId {
   uint32_t x;
@@ -259,7 +259,10 @@ void Solver::createTetBox(
   this->renderStateDirty = true;
 }
 
-void Solver::createBox(const glm::vec3& translation, float scale, float stiffness) {
+void Solver::createBox(
+    const glm::vec3& translation,
+    float scale,
+    float stiffness) {
   Grid grid{5, 5, 5};
 
   size_t currentNodeCount = this->_nodes.size();

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -65,6 +65,7 @@ void Solver::createTetBox(
         node.position = scale * glm::vec3(i, j, k) + translation;
         node.prevPosition = node.position;
         node.velocity = glm::vec3(0.0f);
+        node.radius = 0.5f * scale;
         node.mass = 1.0f;
 
         // if (i == 0 && j == 0) {
@@ -78,6 +79,9 @@ void Solver::createTetBox(
   // Add tetrahedral constraints in each grid cell
   this->_tetConstraints.reserve(
       currentTetConstraintsCount +
+      6 * (grid.width - 1) * (grid.height - 1) * (grid.depth - 1));
+  this->_tets.reserve(
+      this->_tets.size() +
       6 * (grid.width - 1) * (grid.height - 1) * (grid.depth - 1));
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
@@ -95,6 +99,7 @@ void Solver::createTetBox(
         uint32_t node111 =
             grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, k + 1});
 
+        // TODO: consolidate tets and tet constraints
         this->_tetConstraints.push_back(createTetrahedralConstraint(
             this->_constraintId++,
             stiffness,
@@ -102,6 +107,11 @@ void Solver::createTetBox(
             this->_nodes[node001],
             this->_nodes[node011],
             this->_nodes[node111]));
+        this->_tets.push_back(
+            {{this->_nodes[node000].id,
+              this->_nodes[node001].id,
+              this->_nodes[node011].id,
+              this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
             this->_constraintId++,
             stiffness,
@@ -109,6 +119,11 @@ void Solver::createTetBox(
             this->_nodes[node010],
             this->_nodes[node011],
             this->_nodes[node111]));
+        this->_tets.push_back(
+            {{this->_nodes[node000].id,
+              this->_nodes[node010].id,
+              this->_nodes[node011].id,
+              this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
             this->_constraintId++,
             stiffness,
@@ -116,6 +131,11 @@ void Solver::createTetBox(
             this->_nodes[node001],
             this->_nodes[node101],
             this->_nodes[node111]));
+        this->_tets.push_back(
+            {{this->_nodes[node000].id,
+              this->_nodes[node001].id,
+              this->_nodes[node101].id,
+              this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
             this->_constraintId++,
             stiffness,
@@ -123,6 +143,11 @@ void Solver::createTetBox(
             this->_nodes[node100],
             this->_nodes[node101],
             this->_nodes[node111]));
+        this->_tets.push_back(
+            {{this->_nodes[node000].id,
+              this->_nodes[node100].id,
+              this->_nodes[node101].id,
+              this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
             this->_constraintId++,
             stiffness,
@@ -130,6 +155,11 @@ void Solver::createTetBox(
             this->_nodes[node010],
             this->_nodes[node110],
             this->_nodes[node111]));
+        this->_tets.push_back({
+            {this->_nodes[node000].id,
+             this->_nodes[node010].id,
+             this->_nodes[node110].id,
+             this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
             this->_constraintId++,
             stiffness,
@@ -137,6 +167,11 @@ void Solver::createTetBox(
             this->_nodes[node100],
             this->_nodes[node110],
             this->_nodes[node111]));
+        this->_tets.push_back(
+            {{this->_nodes[node000].id,
+              this->_nodes[node100].id,
+              this->_nodes[node110].id,
+              this->_nodes[node111].id}});
       }
     }
   }
@@ -251,6 +286,7 @@ void Solver::createTetBox(
   this->_vertices.resize(this->_nodes.size());
   for (size_t i = currentNodeCount; i < this->_nodes.size(); ++i) {
     this->_vertices[i].position = this->_nodes[i].position;
+    this->_vertices[i].radius = this->_nodes[i].radius;
     this->_vertices[i].baseColor = boxColor;
     this->_vertices[i].roughness = boxRoughness;
     this->_vertices[i].metallic = boxMetallic;
@@ -287,6 +323,7 @@ void Solver::createBox(
         node.position = scale * glm::vec3(i, j, k) + translation;
         node.prevPosition = node.position;
         node.velocity = glm::vec3(0.0f);
+        node.radius = 0.5f * scale;
         node.mass = 1.0f;
 
         // if (i == 0 && j == 0) {
@@ -491,6 +528,7 @@ void Solver::createBox(
   this->_vertices.resize(this->_nodes.size());
   for (size_t i = currentNodeCount; i < this->_nodes.size(); ++i) {
     this->_vertices[i].position = this->_nodes[i].position;
+    this->_vertices[i].radius = this->_nodes[i].radius;
     this->_vertices[i].baseColor = boxColor;
     this->_vertices[i].roughness = boxRoughness;
     this->_vertices[i].metallic = boxMetallic;

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -40,8 +40,9 @@ struct Grid {
 void Solver::createTetBox(
     const glm::vec3& translation,
     float scale,
+    const glm::vec3& initialVelocity,
     float stiffness) {
-  Grid grid{5, 5, 5};
+  Grid grid{3, 3, 3};
 
   size_t currentNodeCount = this->_nodes.size();
   size_t currentTetConstraintsCount = this->_tetConstraints.size();
@@ -64,7 +65,7 @@ void Solver::createTetBox(
         node.id = nodeId;
         node.position = scale * glm::vec3(i, j, k) + translation;
         node.prevPosition = node.position;
-        node.velocity = glm::vec3(0.0f);
+        node.velocity = initialVelocity;
         node.radius = 0.5f * scale;
         node.mass = 1.0f;
 
@@ -155,11 +156,11 @@ void Solver::createTetBox(
             this->_nodes[node010],
             this->_nodes[node110],
             this->_nodes[node111]));
-        this->_tets.push_back({
-            {this->_nodes[node000].id,
-             this->_nodes[node010].id,
-             this->_nodes[node110].id,
-             this->_nodes[node111].id}});
+        this->_tets.push_back(
+            {{this->_nodes[node000].id,
+              this->_nodes[node010].id,
+              this->_nodes[node110].id,
+              this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
             this->_constraintId++,
             stiffness,

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -562,6 +562,7 @@ void Solver::createSheet(const glm::vec3& translation, float scale, float k) {
         node.position = scale * glm::vec3(i, j, j) + translation;
         node.prevPosition = node.position;
         node.velocity = glm::vec3(0.0f);
+        node.radius = 0.5f * scale;
         node.mass = 1.0f;
 
         // if (i == 0 && j == 0) {

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -37,7 +37,229 @@ struct Grid {
 };
 } // namespace
 
-void Solver::createBox(const glm::vec3& translation, float scale, float k) {
+void Solver::createTetBox(
+    const glm::vec3& translation,
+    float scale,
+    float stiffness) {
+  Grid grid{5, 5, 5};
+
+  size_t currentNodeCount = this->_nodes.size();
+  size_t currentTetConstraintsCount = this->_tetConstraints.size();
+  size_t currentLinesCount = this->_lines.size();
+  size_t currentTriCount = this->_triangles.size();
+
+  glm::vec3 boxColor = randColor();
+  float boxRoughness = randf();
+  float boxMetallic = static_cast<float>(std::rand() % 2);
+
+  // Add nodes in a grid
+  this->_nodes.reserve(
+      currentNodeCount + grid.width * grid.height * grid.depth);
+  for (uint32_t i = 0; i < grid.width; ++i) {
+    for (uint32_t j = 0; j < grid.height; ++j) {
+      for (uint32_t k = 0; k < grid.depth; ++k) {
+        uint32_t nodeId = grid.gridIdToNodeId(currentNodeCount, {i, j, k});
+
+        Node& node = this->_nodes.emplace_back();
+        node.id = nodeId;
+        node.position = scale * glm::vec3(i, j, k) + translation;
+        node.prevPosition = node.position;
+        node.velocity = glm::vec3(0.0f);
+        node.mass = 1.0f;
+
+        // if (i == 0 && j == 0) {
+        //   this->_positionConstraints.push_back(
+        //       createPositionConstraint(this->_constraintId++, &node));
+        // }
+      }
+    }
+  }
+
+  // Add tetrahedral constraints in each grid cell
+  this->_tetConstraints.reserve(
+      currentTetConstraintsCount +
+      6 * (grid.width - 1) * (grid.height - 1) * (grid.depth - 1));
+  for (uint32_t i = 0; i < grid.width - 1; ++i) {
+    for (uint32_t j = 0; j < grid.height - 1; ++j) {
+      for (uint32_t k = 0; k < grid.depth - 1; ++k) {
+        uint32_t node000 = grid.gridIdToNodeId(currentNodeCount, {i, j, k});
+        uint32_t node001 = grid.gridIdToNodeId(currentNodeCount, {i, j, k + 1});
+        uint32_t node010 = grid.gridIdToNodeId(currentNodeCount, {i, j + 1, k});
+        uint32_t node011 =
+            grid.gridIdToNodeId(currentNodeCount, {i, j + 1, k + 1});
+        uint32_t node100 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j, k});
+        uint32_t node101 =
+            grid.gridIdToNodeId(currentNodeCount, {i + 1, j, k + 1});
+        uint32_t node110 =
+            grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, k});
+        uint32_t node111 =
+            grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, k + 1});
+
+        this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node001],
+            this->_nodes[node011],
+            this->_nodes[node111]));
+        this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node010],
+            this->_nodes[node011],
+            this->_nodes[node111]));
+        this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node001],
+            this->_nodes[node101],
+            this->_nodes[node111]));
+        this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node100],
+            this->_nodes[node101],
+            this->_nodes[node111]));
+        this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node010],
+            this->_nodes[node110],
+            this->_nodes[node111]));
+        this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node100],
+            this->_nodes[node110],
+            this->_nodes[node111]));
+      }
+    }
+  }
+
+  this->_triangles.reserve(
+      currentTriCount +
+      3 * 2 *
+          (2 * grid.width * grid.height + 2 * grid.width * grid.depth +
+           2 * grid.height * grid.depth));
+  for (uint32_t i = 0; i < grid.width - 1; ++i) {
+    for (uint32_t j = 0; j < grid.height - 1; ++j) {
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, j, grid.depth - 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId(
+          currentNodeCount,
+          {i + 1, j + 1, grid.depth - 1}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}));
+      this->_triangles.push_back(grid.gridIdToNodeId(
+          currentNodeCount,
+          {i + 1, j + 1, grid.depth - 1}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, j + 1, grid.depth - 1}));
+    }
+  }
+
+  for (uint32_t i = 0; i < grid.width - 1; ++i) {
+    for (uint32_t k = 0; k < grid.depth - 1; ++k) {
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, 0, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, 0, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, 0, k + 1}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId(
+          currentNodeCount,
+          {i + 1, grid.height - 1, k + 1}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId(
+          currentNodeCount,
+          {i + 1, grid.height - 1, k + 1}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1}));
+    }
+  }
+
+  for (uint32_t j = 0; j < grid.height - 1; ++j) {
+    for (uint32_t k = 0; k < grid.depth - 1; ++k) {
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {0, j, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {0, j, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j + 1, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId(
+          currentNodeCount,
+          {grid.width - 1, j + 1, k + 1}));
+
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}));
+      this->_triangles.push_back(grid.gridIdToNodeId(
+          currentNodeCount,
+          {grid.width - 1, j + 1, k + 1}));
+      this->_triangles.push_back(
+          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k + 1}));
+    }
+  }
+
+  this->_vertices.resize(this->_nodes.size());
+  for (size_t i = currentNodeCount; i < this->_nodes.size(); ++i) {
+    this->_vertices[i].position = this->_nodes[i].position;
+    this->_vertices[i].baseColor = boxColor;
+    this->_vertices[i].roughness = boxRoughness;
+    this->_vertices[i].metallic = boxMetallic;
+  }
+
+  this->renderStateDirty = true;
+}
+
+void Solver::createBox(const glm::vec3& translation, float scale, float stiffness) {
   Grid grid{5, 5, 5};
 
   size_t currentNodeCount = this->_nodes.size();
@@ -249,7 +471,7 @@ void Solver::createBox(const glm::vec3& translation, float scale, float k) {
        i < this->_distanceConstraints.size();
        ++i) {
     this->_distanceConstraints[i].setWeight(
-        1.0f - powf(1.0f - k, 1.0f / this->_options.iterations));
+        1.0f - powf(1.0f - stiffness, 1.0f / this->_options.iterations));
   }
 
   this->_lines.reserve(

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -9,7 +9,7 @@ void Solver::tick(float /*timestep*/) {
       this->_options.fixedTimestepSize / this->_options.timeSubsteps;
 
   // Time substeps
-  for (int substep = 0; substep < this->_options.timeSubsteps; ++substep) {
+  for (uint32_t substep = 0; substep < this->_options.timeSubsteps; ++substep) {
     // Apply external forces and advect nodes
     for (Node& node : this->_nodes) {
       node.prevPosition = node.position;

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -6,7 +6,8 @@ namespace Pies {
 
 Solver::Solver(const SolverOptions& options)
     : _options(options),
-      _spatialHashNodes(glm::scale(glm::mat4(1.0f), glm::vec3(0.01f))) {}
+      _spatialHashNodes(glm::vec3(0.0f), 0.5f),
+      _spatialHashTets(glm::vec3(0.0f), 0.5f) {}
 
 void Solver::tick(float /*timestep*/) {
   float deltaTime =
@@ -23,8 +24,8 @@ void Solver::tick(float /*timestep*/) {
     }
 
     // TODO: Collision solver
-    this->_spatialHashNodes.clear();
-    this->_spatialHashNodes.parallelBulkInsert(this->_nodes, {});
+    // this->_spatialHashNodes.clear();
+    // this->_spatialHashNodes.parallelBulkInsert(this->_nodes, {});
 
     for (uint32_t i = 0; i < this->_options.iterations; ++i) {
       if (!releaseHinge) {
@@ -44,26 +45,61 @@ void Solver::tick(float /*timestep*/) {
       // // TODO: Collision solver
       // this->_spatialHashTets.clear();
       // this->_spatialHashTets.parallelBulkInsert(this->_tets, {this->_nodes});
-      // // TODO: Apply projections to collision constraints
+
+      this->_spatialHashNodes.clear();
+      this->_spatialHashNodes.parallelBulkInsert(this->_nodes, {});
 
       // Detect and resolve collisions
+      std::vector<SpatialHashGridCellBucket<Node>*> scratchBuckets;
       for (Node& node : this->_nodes) {
-        if (node.position.y < -8.0f) {
-          node.position.y = -8.0f;
+        this->_spatialHashNodes.findCollisions(node, {}, scratchBuckets);
+        for (SpatialHashGridCellBucket<Node>* pBucket : scratchBuckets) {
+          // Check each node within each bucket
+          for (Node* pOtherNode : pBucket->values) {
+            // Check intersection
+            glm::vec3 diff = pOtherNode->position - node.position;
+            float dist = glm::length(diff);
+
+            float disp = node.radius + pOtherNode->radius - dist;
+
+            if (disp <= 0.0) {
+              continue;
+            }
+
+            glm::vec3 dir(1.0f, 0.0f, 0.0f);
+            if (dist > 0.00001f) {
+              dir = diff / dist;
+            }
+
+            float massSum = node.mass + pOtherNode->mass;
+
+            node.position += 0.85f * -disp * dir * node.mass / massSum;
+            pOtherNode->position += 0.85f * disp * dir * pOtherNode->mass / massSum;
+          }
+        }
+
+        scratchBuckets.clear();
+      }
+
+      for (Node& node : this->_nodes) {
+        if (node.position.y - node.radius < this->_options.floorHeight) {
+          node.position.y = this->_options.floorHeight + node.radius;
         }
       }
     }
 
     // Compute new velocity and construct new vertex positions
     for (uint32_t i = 0; i < this->_nodes.size(); ++i) {
-      this->_nodes[i].velocity =
+      Node& node = this->_nodes[i];
+
+      node.velocity =
           (1.0f - this->_options.damping) *
-          (this->_nodes[i].position - this->_nodes[i].prevPosition) / deltaTime;
+          (node.position - node.prevPosition) / deltaTime;
 
       // TODO: friction for dynamically generated constraints
-      if (this->_nodes[i].position.y <= -8.0f) {
-        this->_nodes[i].velocity.x *= 1.0f - this->_options.friction;
-        this->_nodes[i].velocity.z *= 1.0f - this->_options.friction;
+      if (node.position.y - node.radius <= this->_options.floorHeight) {
+        node.velocity.x *= 1.0f - this->_options.friction;
+        node.velocity.z *= 1.0f - this->_options.friction;
       }
 
       this->_vertices[i].position = this->_nodes[i].position;
@@ -74,18 +110,21 @@ void Solver::tick(float /*timestep*/) {
 SpatialHashGridCellRange Solver::NodeCompRange::operator()(
     const Node& node,
     const SpatialHashGrid& grid) const {
-  glm::vec3 gridLocalPos =
-      glm::vec3(grid.worldToGrid * glm::vec4(node.position, 1.0f));
+  float radiusPadding = 0.0f;
+  float gridLocalRadius = (node.radius + radiusPadding) / grid.scale;
+  glm::vec3 gridLocalPos = (node.position - grid.translation) / grid.scale;
+  glm::vec3 gridLocalMin = gridLocalPos - glm::vec3(gridLocalRadius);
 
   SpatialHashGridCellRange range{};
-  range.minX = static_cast<int64_t>(gridLocalPos.x);
-  range.minY = static_cast<int64_t>(gridLocalPos.y);
-  range.minZ = static_cast<int64_t>(gridLocalPos.z);
+  range.minX = static_cast<int64_t>(glm::floor(gridLocalMin.x));
+  range.minY = static_cast<int64_t>(glm::floor(gridLocalMin.y));
+  range.minZ = static_cast<int64_t>(glm::floor(gridLocalMin.z));
 
-  // Assume infinitely small
-  range.lengthX = 1;
-  range.lengthY = 1;
-  range.lengthZ = 1;
+  glm::vec3 adjustedDiameter =
+      glm::round(glm::fract(gridLocalMin) + glm::vec3(2 * gridLocalRadius));
+  range.lengthX = static_cast<uint32_t>(adjustedDiameter.r);
+  range.lengthY = static_cast<uint32_t>(adjustedDiameter.g);
+  range.lengthZ = static_cast<uint32_t>(adjustedDiameter.b);
 
   return range;
 }
@@ -93,22 +132,25 @@ SpatialHashGridCellRange Solver::NodeCompRange::operator()(
 SpatialHashGridCellRange Solver::TetCompRange::operator()(
     const Tetrahedron& tet,
     const SpatialHashGrid& grid) const {
-  glm::vec3 x1 = glm::vec3(
-      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[0]].position, 1.0f));
-  glm::vec3 x2 = glm::vec3(
-      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[1]].position, 1.0f));
-  glm::vec3 x3 = glm::vec3(
-      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[2]].position, 1.0f));
-  glm::vec3 x4 = glm::vec3(
-      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[3]].position, 1.0f));
+  glm::vec3 x1 =
+      (nodes[tet.nodeIds[0]].position - grid.translation) / grid.scale;
+  glm::vec3 x2 =
+      (nodes[tet.nodeIds[1]].position - grid.translation) / grid.scale;
+  glm::vec3 x3 =
+      (nodes[tet.nodeIds[2]].position - grid.translation) / grid.scale;
+  glm::vec3 x4 =
+      (nodes[tet.nodeIds[3]].position - grid.translation) / grid.scale;
+
+  glm::vec3 min(std::numeric_limits<float>::max());
+  glm::vec3 max(std::numeric_limits<float>::lowest());
 
   SpatialHashGridCellRange range{};
   range.minX = static_cast<int64_t>(
-      glm::min(glm::min(glm::min(x1.x, x2.x), x3.x), x4.x));
+      glm::floor(glm::min(glm::min(glm::min(x1.x, x2.x), x3.x), x4.x)));
   range.minY = static_cast<int64_t>(
-      glm::min(glm::min(glm::min(x1.y, x2.y), x3.y), x4.y));
+      glm::floor(glm::min(glm::min(glm::min(x1.y, x2.y), x3.y), x4.y)));
   range.minZ = static_cast<int64_t>(
-      glm::min(glm::min(glm::min(x1.z, x2.z), x3.z), x4.z));
+      glm::floor(glm::min(glm::min(glm::min(x1.z, x2.z), x3.z), x4.z)));
 
   range.lengthX = glm::max(
       static_cast<uint32_t>(

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -76,6 +76,14 @@ void Solver::tick(float /*timestep*/) {
 
             node.position += 0.85f * -disp * dir * node.mass / massSum;
             pOtherNode->position += 0.85f * disp * dir * pOtherNode->mass / massSum;
+
+            // TODO: Add friction between dynamic objects
+            glm::vec3 relativeVelocity = pOtherNode->velocity - node.velocity;
+            glm::vec3 perpVel = relativeVelocity - glm::dot(relativeVelocity, dir) * dir;
+
+            // TODO: Decouple friction from solver iteration count
+            node.velocity += -this->_options.friction * perpVel * node.mass / massSum;
+            pOtherNode->velocity += this->_options.friction * perpVel * pOtherNode->mass / massSum;
           }
         }
 
@@ -106,6 +114,20 @@ void Solver::tick(float /*timestep*/) {
       this->_vertices[i].position = this->_nodes[i].position;
     }
   }
+}
+
+void Solver::clear() {
+  this->_lines.clear();
+  this->_triangles.clear();
+  this->_nodes.clear();
+  this->_distanceConstraints.clear();
+  this->_tetConstraints.clear();
+  this->_tets.clear();
+  this->_positionConstraints.clear();
+  this->_vertices.clear();
+  this->_constraintId = 0;
+
+  this->renderStateDirty = true;
 }
 
 SpatialHashGridCellRange Solver::NodeCompRange::operator()(

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -37,6 +37,10 @@ void Solver::tick(float /*timestep*/) {
         constraint.projectNodePositions(this->_nodes);
       }
 
+      for (TetrahedralConstraint& constraint : this->_tetConstraints) {
+        constraint.projectNodePositions(this->_nodes);
+      }
+
       // TODO: Collision solver
       this->_spatialHashNodes.clear();
       this->_spatialHashNodes.parallelBulkInsert(this->_nodes);

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -4,9 +4,9 @@
 
 namespace Pies {
 
-Solver::Solver(const SolverOptions& options) : 
-    _options(options),
-    _spatialHashNodes(glm::scale(glm::mat4(1.0f), glm::vec3(0.01f))) {}
+Solver::Solver(const SolverOptions& options)
+    : _options(options),
+      _spatialHashNodes(glm::scale(glm::mat4(1.0f), glm::vec3(0.01f))) {}
 
 void Solver::tick(float /*timestep*/) {
   float deltaTime =
@@ -23,8 +23,8 @@ void Solver::tick(float /*timestep*/) {
     }
 
     // TODO: Collision solver
-    // this->_spatialHashNodes.clear();
-    // this->_spatialHashNodes.parallelBulkInsert(this->_nodes);
+    this->_spatialHashNodes.clear();
+    this->_spatialHashNodes.parallelBulkInsert(this->_nodes, {});
 
     for (uint32_t i = 0; i < this->_options.iterations; ++i) {
       if (!releaseHinge) {
@@ -41,12 +41,12 @@ void Solver::tick(float /*timestep*/) {
         constraint.projectNodePositions(this->_nodes);
       }
 
-      // TODO: Collision solver
-      this->_spatialHashNodes.clear();
-      this->_spatialHashNodes.parallelBulkInsert(this->_nodes);
-      // TODO: Apply projections to collision constraints
+      // // TODO: Collision solver
+      // this->_spatialHashTets.clear();
+      // this->_spatialHashTets.parallelBulkInsert(this->_tets, {this->_nodes});
+      // // TODO: Apply projections to collision constraints
 
-      // Floor constraint
+      // Detect and resolve collisions
       for (Node& node : this->_nodes) {
         if (node.position.y < -8.0f) {
           node.position.y = -8.0f;
@@ -71,10 +71,11 @@ void Solver::tick(float /*timestep*/) {
   }
 }
 
-SpatialHashGridCellRange
-Solver::NodeCompRange::operator()(const Node& node) const {
+SpatialHashGridCellRange Solver::NodeCompRange::operator()(
+    const Node& node,
+    const SpatialHashGrid& grid) const {
   glm::vec3 gridLocalPos =
-      glm::vec3(this->grid.worldToGrid * glm::vec4(node.position, 1.0f));
+      glm::vec3(grid.worldToGrid * glm::vec4(node.position, 1.0f));
 
   SpatialHashGridCellRange range{};
   range.minX = static_cast<int64_t>(gridLocalPos.x);
@@ -85,6 +86,42 @@ Solver::NodeCompRange::operator()(const Node& node) const {
   range.lengthX = 1;
   range.lengthY = 1;
   range.lengthZ = 1;
+
+  return range;
+}
+
+SpatialHashGridCellRange Solver::TetCompRange::operator()(
+    const Tetrahedron& tet,
+    const SpatialHashGrid& grid) const {
+  glm::vec3 x1 = glm::vec3(
+      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[0]].position, 1.0f));
+  glm::vec3 x2 = glm::vec3(
+      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[1]].position, 1.0f));
+  glm::vec3 x3 = glm::vec3(
+      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[2]].position, 1.0f));
+  glm::vec3 x4 = glm::vec3(
+      grid.worldToGrid * glm::vec4(nodes[tet.nodeIds[3]].position, 1.0f));
+
+  SpatialHashGridCellRange range{};
+  range.minX = static_cast<int64_t>(
+      glm::min(glm::min(glm::min(x1.x, x2.x), x3.x), x4.x));
+  range.minY = static_cast<int64_t>(
+      glm::min(glm::min(glm::min(x1.y, x2.y), x3.y), x4.y));
+  range.minZ = static_cast<int64_t>(
+      glm::min(glm::min(glm::min(x1.z, x2.z), x3.z), x4.z));
+
+  range.lengthX = glm::max(
+      static_cast<uint32_t>(
+          glm::max(glm::max(glm::max(x1.x, x2.x), x3.x), x4.x) - range.minX),
+      1u);
+  range.lengthY = glm::max(
+      static_cast<uint32_t>(
+          glm::max(glm::max(glm::max(x1.y, x2.y), x3.y), x4.y) - range.minY),
+      1u);
+  range.lengthZ = glm::max(
+      static_cast<uint32_t>(
+          glm::max(glm::max(glm::max(x1.z, x2.z), x3.z), x4.z) - range.minZ),
+      1u);
 
   return range;
 }


### PR DESCRIPTION
Changes:
- Implements a spatial hash using the phmap library.
- Uses the spatial hash for dynamic node-node collisions.
- Adds a radius property to nodes, to allow defining their collisions
- Adds tetrahedral strain constraint
- Adds tetrahedral volume preservation constraint
- Adds function to create box of tetrahedral strain constraints
- Adds function to clear the simulation objects.