### PR TITLE
Triangle CCD + Solver Refactor

### DIFF
--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -11,7 +11,7 @@
 namespace Pies {
 // Generalize to different types of collision
 struct CollisionConstraint {
-  float w = 10000.0f;
+  float w = 100000.0f;
   uint32_t nodeIds[2];
   glm::vec3 projectedPositions[2];
   glm::vec3 n;
@@ -21,7 +21,10 @@ struct CollisionConstraint {
   void
   setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
 
-  void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
+  void setupGlobalForceVector(
+      Eigen::MatrixXf& forceVector,
+      uint32_t threadId,
+      uint32_t threadCount) const;
 };
 
 struct StaticCollisionConstraint {

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -29,11 +29,13 @@ struct CollisionConstraint {
 };
 
 struct PointTriangleCollisionConstraint {
-  float w = 100000.0f;
+  float w = 10000.0f;
   uint32_t nodeIds[4];
   glm::vec3 projectedPositions[4];
   glm::vec3 n;
-  float thickness = 0.1f;
+  // A == B
+  Eigen::Matrix4f AtA;
+  float thickness = 0.01f;
   bool colliding = false;
 
   PointTriangleCollisionConstraint(
@@ -48,25 +50,23 @@ struct PointTriangleCollisionConstraint {
   void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
 };
 
-// struct EdgeCollisionConstraint {
-//   float w = 100000.0f;
-//   uint32_t nodeIds[4];
-//   glm::vec3 projectedPositions[4];
-//   glm::vec3 n;
-//   float thickness = 0.1f;
-//   bool colliding = false;
+struct EdgeCollisionConstraint {
+  float w = 100000.0f;
+  uint32_t nodeIds[4];
+  glm::vec3 projectedPositions[4];
+  float thickness = 0.01f;
 
-//   PointTriangleCollisionConstraint(
-//       const Node& a,
-//       const Node& b,
-//       const Node& c,
-//       const Node& d);
+  EdgeCollisionConstraint(
+      const Node& a,
+      const Node& b,
+      const Node& c,
+      const Node& d);
 
-//   void projectToAuxiliaryVariable(const std::vector<Node>& nodes);
-//   void stabilizeCollisions(std::vector<Node>& nodes);
-//   void setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
-//   void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
-// };
+  void projectToAuxiliaryVariable(const std::vector<Node>& nodes);
+  void stabilizeCollisions(std::vector<Node>& nodes);
+  void setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
+  void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
+};
 
 struct StaticCollisionConstraint {
   float w = 10000.0f;

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -29,11 +29,12 @@ struct CollisionConstraint {
 };
 
 struct PointTriangleCollisionConstraint {
-  float w = 10000.0f;
+  float w = 100000.0f;
   uint32_t nodeIds[4];
   glm::vec3 projectedPositions[4];
   glm::vec3 n;
-  float thickness = 0.1f;
+  float thickness = 0.15f;
+  bool colliding = false;
 
   PointTriangleCollisionConstraint(
       const Node& a,
@@ -48,7 +49,7 @@ struct PointTriangleCollisionConstraint {
 };
 
 struct StaticCollisionConstraint {
-  float w = 1000000.0f;
+  float w = 10000.0f;
   uint32_t nodeId;
   glm::vec3 projectedPosition;
 

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -33,7 +33,7 @@ struct PointTriangleCollisionConstraint {
   uint32_t nodeIds[4];
   glm::vec3 projectedPositions[4];
   glm::vec3 n;
-  bool colliding = false;
+  float thickness = 0.1f;
 
   PointTriangleCollisionConstraint(
       const Node& a,
@@ -42,6 +42,7 @@ struct PointTriangleCollisionConstraint {
       const Node& d);
 
   void projectToAuxiliaryVariable(const std::vector<Node>& nodes);
+  void stabilizeCollisions(std::vector<Node>& nodes);
   void setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
   void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
 };

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -51,10 +51,14 @@ struct PointTriangleCollisionConstraint {
 };
 
 struct EdgeCollisionConstraint {
-  float w = 100000.0f;
+  float w = 1000000.0f;
   uint32_t nodeIds[4];
   glm::vec3 projectedPositions[4];
-  float thickness = 0.01f;
+  Eigen::Matrix4f AtA;
+
+  float orientation = 1.0f;
+
+  float thickness = 0.1f;
 
   EdgeCollisionConstraint(
       const Node& a,

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -48,6 +48,26 @@ struct PointTriangleCollisionConstraint {
   void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
 };
 
+// struct EdgeCollisionConstraint {
+//   float w = 100000.0f;
+//   uint32_t nodeIds[4];
+//   glm::vec3 projectedPositions[4];
+//   glm::vec3 n;
+//   float thickness = 0.1f;
+//   bool colliding = false;
+
+//   PointTriangleCollisionConstraint(
+//       const Node& a,
+//       const Node& b,
+//       const Node& c,
+//       const Node& d);
+
+//   void projectToAuxiliaryVariable(const std::vector<Node>& nodes);
+//   void stabilizeCollisions(std::vector<Node>& nodes);
+//   void setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
+//   void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
+// };
+
 struct StaticCollisionConstraint {
   float w = 10000.0f;
   uint32_t nodeId;

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -29,7 +29,7 @@ struct CollisionConstraint {
 };
 
 struct PointTriangleCollisionConstraint {
-  float w = 100000.0f;
+  float w = 10000.0f;
   uint32_t nodeIds[4];
   glm::vec3 projectedPositions[4];
   glm::vec3 n;
@@ -47,7 +47,7 @@ struct PointTriangleCollisionConstraint {
 };
 
 struct StaticCollisionConstraint {
-  float w = 100000.0f;
+  float w = 1000000.0f;
   uint32_t nodeId;
   glm::vec3 projectedPosition;
 

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -33,7 +33,7 @@ struct PointTriangleCollisionConstraint {
   uint32_t nodeIds[4];
   glm::vec3 projectedPositions[4];
   glm::vec3 n;
-  float thickness = 0.15f;
+  float thickness = 0.1f;
   bool colliding = false;
 
   PointTriangleCollisionConstraint(

--- a/Include/Pies/CollisionConstraint.h
+++ b/Include/Pies/CollisionConstraint.h
@@ -16,10 +16,11 @@ struct CollisionConstraint {
   glm::vec3 projectedPositions[2];
   glm::vec3 n;
 
-  CollisionConstraint(const Node& a, const Node& b, const glm::vec3& disp);
+  CollisionConstraint(const Node& a, const Node& b);
 
-  void
-  setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
+  void projectToAuxiliaryVariable(const std::vector<Node>& nodes);
+
+  void setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
 
   void setupGlobalForceVector(
       Eigen::MatrixXf& forceVector,
@@ -27,17 +28,36 @@ struct CollisionConstraint {
       uint32_t threadCount) const;
 };
 
+struct PointTriangleCollisionConstraint {
+  float w = 100000.0f;
+  uint32_t nodeIds[4];
+  glm::vec3 projectedPositions[4];
+  glm::vec3 n;
+  bool colliding = false;
+
+  PointTriangleCollisionConstraint(
+      const Node& a,
+      const Node& b,
+      const Node& c,
+      const Node& d);
+
+  void projectToAuxiliaryVariable(const std::vector<Node>& nodes);
+  void setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
+  void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
+};
+
 struct StaticCollisionConstraint {
-  float w = 10000.0f;
+  float w = 100000.0f;
   uint32_t nodeId;
   glm::vec3 projectedPosition;
 
   glm::vec3 n;
 
-  StaticCollisionConstraint(const Node& node, const glm::vec3& projectedPosition);
+  StaticCollisionConstraint(
+      const Node& node,
+      const glm::vec3& projectedPosition);
 
-  void
-  setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
+  void setupCollisionMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
 
   void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
 };

--- a/Include/Pies/CollisionDetection.h
+++ b/Include/Pies/CollisionDetection.h
@@ -6,7 +6,6 @@
 
 namespace Pies {
 namespace CollisionDetection {
-
 std::optional<float> pointTriangleCCD(
     const glm::vec3& ap0,
     const glm::vec3& ab0,

--- a/Include/Pies/CollisionDetection.h
+++ b/Include/Pies/CollisionDetection.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <glm/glm.hpp>
+
+#include <optional>
+
+namespace Pies {
+namespace CollisionDetection {
+
+std::optional<float> linearCCD(
+    const glm::vec3& ap0,
+    const glm::vec3& ab0,
+    const glm::vec3& ac0,
+    const glm::vec3& ap1,
+    const glm::vec3& ab1,
+    const glm::vec3& ac1);
+} // namespace CollisionDetection
+} // namespace Pies

--- a/Include/Pies/CollisionDetection.h
+++ b/Include/Pies/CollisionDetection.h
@@ -7,12 +7,20 @@
 namespace Pies {
 namespace CollisionDetection {
 
-std::optional<float> linearCCD(
+std::optional<float> pointTriangleCCD(
     const glm::vec3& ap0,
     const glm::vec3& ab0,
     const glm::vec3& ac0,
     const glm::vec3& ap1,
     const glm::vec3& ab1,
     const glm::vec3& ac1);
+    
+std::optional<float> edgeEdgeCCD(
+    const glm::vec3& ab0,
+    const glm::vec3& ac0,
+    const glm::vec3& ad0,
+    const glm::vec3& ab1,
+    const glm::vec3& ac1,
+    const glm::vec3& ad1);
 } // namespace CollisionDetection
 } // namespace Pies

--- a/Include/Pies/Constraints.h
+++ b/Include/Pies/Constraints.h
@@ -164,6 +164,7 @@ typedef Constraint<1, PositionConstraintProjection> PositionConstraint;
 PositionConstraint createPositionConstraint(uint32_t id, const Node& node, float w);
 
 struct TetrahedralConstraintProjection {
+  glm::mat3 Q;
   glm::mat3 Qinv;
 
   void operator()(

--- a/Include/Pies/Constraints.h
+++ b/Include/Pies/Constraints.h
@@ -72,7 +72,7 @@ public:
     // Note: We only fill in the lower triangular part of the matrix.
     for (uint32_t i = 0; i < NodeCount; ++i) {
       uint32_t nodeId_i = this->_nodeIds[i];
-      for (uint32_t j = 0; j <= i; ++j) {
+      for (uint32_t j = 0; j < NodeCount; ++j) {
         uint32_t nodeId_j = this->_nodeIds[j];
         systemMatrix.coeffRef(nodeId_i, nodeId_j) +=
             this->_w * this->_AtA.coeff(i, j);

--- a/Include/Pies/ShapeMatchingConstraint.h
+++ b/Include/Pies/ShapeMatchingConstraint.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Node.h"
+
+#include <Eigen/Core>
+#include <Eigen/Sparse>
+#include <glm/glm.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace Pies {
+class ShapeMatchingConstraint {
+public:
+  ShapeMatchingConstraint(
+      const std::vector<uint32_t>& indices,
+      const std::vector<glm::vec3>& materialCoordinates,
+      float w);
+
+  void
+  setupGlobalStiffnessMatrix(Eigen::SparseMatrix<float>& systemMatrix) const;
+  void setupGlobalForceVector(Eigen::MatrixXf& forceVector) const;
+  void projectToAuxiliaryVariable(const std::vector<Node>& nodes);
+
+private:
+  std::vector<uint32_t> _nodeIndices;
+
+  Eigen::MatrixXf _currentPositions;
+  Eigen::MatrixXf _materialCoordinates;
+
+  Eigen::MatrixXf _projectedPositions;
+  
+  float _w;
+};
+} // namespace Pies

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -21,7 +21,7 @@ namespace Pies {
 enum class SolverName { PBD, PD };
 
 struct SolverOptions {
-  uint32_t iterations = 20;
+  uint32_t iterations = 4;
   uint32_t collisionIterations = 0;
   uint32_t collisionStabilizationIterations = 20;//4;
   float collionStiffness = 1.0f;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <thread>
 
 namespace Pies {
 enum class SolverName { PBD, PD };
@@ -25,10 +26,10 @@ struct SolverOptions {
   float gravity = 10.0f;
   float damping = 0.0005f;
   float friction = 0.05f;
-  float staticFrictionThreshold = 0.0f;
+  float staticFrictionThreshold = 0.1f;
   float floorHeight = 0.0f;
   float gridSpacing = 1.0f;
-  uint32_t threadCount = 12;
+  uint32_t threadCount = 16;
   SolverName solver = SolverName::PD;
 };
 
@@ -48,6 +49,10 @@ public:
 
   Solver() = default;
   Solver(const SolverOptions& options);
+  Solver(Solver&& rhs) = default;
+  Solver& operator=(Solver&& rhs) = default;
+
+  ~Solver();
 
   void tick(float deltaTime);
   void tickPBD(float deltaTime);
@@ -79,6 +84,11 @@ public:
       uint32_t countX,
       uint32_t countY,
       uint32_t countZ,
+      float scale,
+      const glm::vec3& initialVelocity,
+      float w);
+  void createShapeMatchingSheet(
+      const glm::vec3& translation,
       float scale,
       const glm::vec3& initialVelocity,
       float w);
@@ -131,6 +141,8 @@ private:
 
   std::vector<CollisionConstraint> _collisions;
   std::vector<StaticCollisionConstraint> _staticCollisions;
+
+  std::thread _clearSpatialHashThread;
 
   // TODO: Seperate into individual buffers for each object??
   std::vector<uint32_t> _triangles;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -5,6 +5,7 @@
 #include "Node.h"
 #include "SpatialHash.h"
 #include "Tetrahedron.h"
+#include "ShapeMatchingConstraint.h"
 
 #include <Eigen/Core>
 #include <Eigen/SparseCholesky>
@@ -23,7 +24,7 @@ struct SolverOptions {
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
   float damping = 0.0005f;
-  float friction = 0.01f;
+  float friction = 0.05f;
   float staticFrictionThreshold = 0.0f;
   float floorHeight = 0.0f;
   float gridSpacing = 1.0f;
@@ -73,6 +74,14 @@ public:
       bool hinged);
   void
   createSheet(const glm::vec3& translation, float scale, float mass, float k);
+  void createShapeMatchingBox(
+      const glm::vec3& translation,
+      uint32_t countX,
+      uint32_t countY,
+      uint32_t countZ,
+      float scale,
+      const glm::vec3& initialVelocity,
+      float w);
 
 private:
   void _computeCollisions();
@@ -101,6 +110,7 @@ private:
   std::vector<PositionConstraint> _positionConstraints;
   std::vector<DistanceConstraint> _distanceConstraints;
   std::vector<TetrahedralConstraint> _tetConstraints;
+  std::vector<ShapeMatchingConstraint> _shapeConstraints;
 
   uint32_t _previousNodeCount = 0;
   Eigen::MatrixXf _stateVector;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -28,11 +28,11 @@ struct SolverOptions {
   uint32_t timeSubsteps = 1;
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
-  float damping = 0.005f;
-  float friction = 0.025f;//1f;
+  float damping = 0.001f;
+  float friction = 0.001f;//1f;
   float staticFrictionThreshold = 0.f;//1.0f;
   float floorHeight = 0.0f;
-  float gridSpacing = 1.0f;
+  float gridSpacing = 2.0f;
   uint32_t threadCount = 8;
   SolverName solver = SolverName::PD;
 };

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -21,15 +21,15 @@ namespace Pies {
 enum class SolverName { PBD, PD };
 
 struct SolverOptions {
-  uint32_t iterations = 10;
+  uint32_t iterations = 20;
   uint32_t collisionIterations = 0;
-  uint32_t collisionStabilizationIterations = 4;
+  uint32_t collisionStabilizationIterations = 20;//4;
   float collionStiffness = 1.0f;
   uint32_t timeSubsteps = 1;
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
-  float damping = 0.001f;
-  float friction = 0.001f;//1f;
+  float damping = 0.004f;
+  float friction = 0.01f;//1f;
   float staticFrictionThreshold = 0.f;//1.0f;
   float floorHeight = 0.0f;
   float gridSpacing = 2.0f;
@@ -158,6 +158,7 @@ private:
   struct ThreadData {
     std::vector<CollisionConstraint> collisions;
     std::vector<PointTriangleCollisionConstraint> triCollisions;
+    std::vector<EdgeCollisionConstraint> edgeCollisions;
     std::vector<StaticCollisionConstraint> staticCollisions;
   };
 
@@ -165,6 +166,7 @@ private:
 
   std::vector<CollisionConstraint> _collisions;
   std::vector<PointTriangleCollisionConstraint> _triCollisions;
+  std::vector<EdgeCollisionConstraint> _edgeCollisions;
   std::vector<StaticCollisionConstraint> _staticCollisions;
 
   std::thread _clearSpatialHashThread;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -21,16 +21,16 @@ namespace Pies {
 enum class SolverName { PBD, PD };
 
 struct SolverOptions {
-  uint32_t iterations = 14;
-  uint32_t collisionIterations = 1;
-  uint32_t collisionStabilizationIterations = 1;
+  uint32_t iterations = 50;
+  uint32_t collisionIterations = 0;
+  uint32_t collisionStabilizationIterations = 5;
   float collionStiffness = 1.0f;
   uint32_t timeSubsteps = 2;
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
   float damping = 0.001f;
-  float friction = 0.5f;
-  float staticFrictionThreshold = 0.0f;
+  float friction = 0.1f;//1f;//1f;
+  float staticFrictionThreshold = 1.0f;//1.0f;
   float floorHeight = 0.0f;
   float gridSpacing = 1.0f;
   uint32_t threadCount = 8;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -21,15 +21,16 @@ namespace Pies {
 enum class SolverName { PBD, PD };
 
 struct SolverOptions {
-  uint32_t iterations = 8;
-  uint32_t collisionIterations = 0;
-  float collionStiffness = 0.01f;
-  uint32_t timeSubsteps = 1;
+  uint32_t iterations = 14;
+  uint32_t collisionIterations = 1;
+  uint32_t collisionStabilizationIterations = 1;
+  float collionStiffness = 1.0f;
+  uint32_t timeSubsteps = 2;
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
-  float damping = 0.0005f;
-  float friction = 0.f;//8f;
-  float staticFrictionThreshold = 0.f;//2.0f;
+  float damping = 0.001f;
+  float friction = 0.5f;
+  float staticFrictionThreshold = 0.0f;
   float floorHeight = 0.0f;
   float gridSpacing = 1.0f;
   uint32_t threadCount = 8;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -62,6 +62,9 @@ public:
 
   void clear();
 
+  // Utilities for importing meshes
+  void addNodes(const std::vector<glm::vec3>& vertices);
+  
   // Utilities for spawning primitives
   void createBox(const glm::vec3& translation, float scale, float stiffness);
   void createTetBox(

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -21,15 +21,15 @@ namespace Pies {
 enum class SolverName { PBD, PD };
 
 struct SolverOptions {
-  uint32_t iterations = 4;
-  uint32_t collisionIterations = 20;
-  float collionStiffness = 1.0f;
+  uint32_t iterations = 8;
+  uint32_t collisionIterations = 0;
+  float collionStiffness = 0.01f;
   uint32_t timeSubsteps = 1;
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
   float damping = 0.0005f;
-  float friction = 0.1f;
-  float staticFrictionThreshold = 0.1f;
+  float friction = 0.f;//8f;
+  float staticFrictionThreshold = 0.f;//2.0f;
   float floorHeight = 0.0f;
   float gridSpacing = 1.0f;
   uint32_t threadCount = 8;
@@ -132,6 +132,7 @@ private:
   std::vector<PositionConstraint> _positionConstraints;
   std::vector<DistanceConstraint> _distanceConstraints;
   std::vector<TetrahedralConstraint> _tetConstraints;
+  std::vector<VolumeConstraint> _volumeConstraints;
   std::vector<ShapeMatchingConstraint> _shapeConstraints;
 
   uint32_t _previousNodeCount = 0;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -64,7 +64,11 @@ public:
 
   // Utilities for importing meshes
   void addNodes(const std::vector<glm::vec3>& vertices);
-  
+  void addTriMeshVolume(
+      const std::vector<glm::vec3>& vertices,
+      const std::vector<uint32_t>& triIndices,
+      float w);
+
   // Utilities for spawning primitives
   void createBox(const glm::vec3& translation, float scale, float w);
   void createTetBox(
@@ -74,7 +78,8 @@ public:
       float w,
       float mass,
       bool hinged);
-  void createSheet(const glm::vec3& translation, float scale, float mass, float w);
+  void
+  createSheet(const glm::vec3& translation, float scale, float mass, float w);
   void createBendSheet(const glm::vec3& translation, float scale, float w);
 
 private:

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -23,12 +23,12 @@ enum class SolverName { PBD, PD };
 struct SolverOptions {
   uint32_t iterations = 4;
   uint32_t collisionIterations = 0;
-  uint32_t collisionStabilizationIterations = 20;//4;
+  uint32_t collisionStabilizationIterations = 4;
   float collionStiffness = 1.0f;
   uint32_t timeSubsteps = 1;
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
-  float damping = 0.004f;
+  float damping = 0.006f;
   float friction = 0.01f;//1f;
   float staticFrictionThreshold = 0.f;//1.0f;
   float floorHeight = 0.0f;

--- a/Include/Pies/Solver.h
+++ b/Include/Pies/Solver.h
@@ -21,16 +21,16 @@ namespace Pies {
 enum class SolverName { PBD, PD };
 
 struct SolverOptions {
-  uint32_t iterations = 50;
+  uint32_t iterations = 10;
   uint32_t collisionIterations = 0;
-  uint32_t collisionStabilizationIterations = 5;
+  uint32_t collisionStabilizationIterations = 4;
   float collionStiffness = 1.0f;
-  uint32_t timeSubsteps = 2;
+  uint32_t timeSubsteps = 1;
   float fixedTimestepSize = 0.012f;
   float gravity = 10.0f;
-  float damping = 0.001f;
-  float friction = 0.1f;//1f;//1f;
-  float staticFrictionThreshold = 1.0f;//1.0f;
+  float damping = 0.005f;
+  float friction = 0.025f;//1f;
+  float staticFrictionThreshold = 0.f;//1.0f;
   float floorHeight = 0.0f;
   float gridSpacing = 1.0f;
   uint32_t threadCount = 8;

--- a/Include/Pies/SpatialHash.h
+++ b/Include/Pies/SpatialHash.h
@@ -102,7 +102,7 @@ public:
       const TCompRange& compRangeFn) {
     // NOTE: Based on example given in:
     // https://greg7mdp.github.io/parallel-hashmap/
-    constexpr size_t numThreads = 8; // has to be a power of two
+    constexpr size_t numThreads = 16; // has to be a power of two
     std::unique_ptr<std::thread> threads[numThreads];
     auto threadFn = [&grid = this->_grid,
                      &hash = this->_hashMap,

--- a/Include/Pies/Triangle.h
+++ b/Include/Pies/Triangle.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Pies {
+struct Triangle {
+  uint32_t nodeIds[3];
+};
+} // namespace Pies

--- a/Src/CollisionConstraint.cpp
+++ b/Src/CollisionConstraint.cpp
@@ -3,28 +3,45 @@
 #include <algorithm>
 
 namespace Pies {
-CollisionConstraint::CollisionConstraint(
-    const Node& a,
-    const Node& b,
-    const glm::vec3& disp)
-    : nodeIds{a.id, b.id}, 
-      n(0.0f) {
-        
-  float wSum = a.invMass + b.invMass;
+CollisionConstraint::CollisionConstraint(const Node& a, const Node& b)
+    : nodeIds{a.id, b.id}, n(0.0f) {}
 
-  this->projectedPositions[0] = a.position - disp * a.invMass / wSum;
-  this->projectedPositions[1] = b.position + disp * b.invMass / wSum;
+void CollisionConstraint::projectToAuxiliaryVariable(
+    const std::vector<Node>& nodes) {
+  const Node& nodeA = nodes[this->nodeIds[0]];
+  const Node& nodeB = nodes[this->nodeIds[1]];
 
-  float dispLength = glm::length(disp);
-  if (dispLength > 0.00001f) {
-    this->n = disp / dispLength;
+  this->projectedPositions[0] = nodeA.position;
+  this->projectedPositions[1] = nodeB.position;
+
+  glm::vec3 diff = nodeB.position - nodeA.position;
+  float distSq = glm::dot(diff, diff);
+  float r = nodeA.radius + nodeB.radius;
+  float rSq = r * r;
+  if (distSq >= rSq) {
+    return;
   }
+
+  float dist = sqrt(distSq);
+  float dispLength = r - dist;
+
+  glm::vec3 disp;
+  if (dist > 0.00001f) {
+    disp = dispLength * diff / dist;
+  } else {
+    disp = glm::vec3(dispLength, 0.0f, 0.0f);
+  }
+
+  float wSum = nodeA.invMass + nodeB.invMass;
+
+  this->projectedPositions[0] -= disp * nodeA.invMass / wSum;
+  this->projectedPositions[1] += disp * nodeB.invMass / wSum;
 }
 
 void CollisionConstraint::setupCollisionMatrix(
     Eigen::SparseMatrix<float>& systemMatrix) const {
   systemMatrix.coeffRef(nodeIds[0], nodeIds[0]) += this->w;
-  systemMatrix.coeffRef(nodeIds[1], nodeIds[1]) += this->w;  
+  systemMatrix.coeffRef(nodeIds[1], nodeIds[1]) += this->w;
 }
 
 void CollisionConstraint::setupGlobalForceVector(
@@ -46,12 +63,133 @@ void CollisionConstraint::setupGlobalForceVector(
   }
 }
 
+PointTriangleCollisionConstraint::PointTriangleCollisionConstraint(
+    const Node& a,
+    const Node& b,
+    const Node& c,
+    const Node& d)
+    : nodeIds{a.id, b.id, c.id, d.id}, n(0.0f) {}
+
+void PointTriangleCollisionConstraint::projectToAuxiliaryVariable(
+    const std::vector<Node>& nodes) {
+  this->colliding = false;
+
+  const Node& nodeA = nodes[nodeIds[0]];
+  const Node& nodeB = nodes[nodeIds[1]];
+  const Node& nodeC = nodes[nodeIds[2]];
+  const Node& nodeD = nodes[nodeIds[3]];
+
+  this->projectedPositions[0] = nodeA.position;
+  this->projectedPositions[1] = nodeB.position;
+  this->projectedPositions[2] = nodeC.position;
+  this->projectedPositions[3] = nodeD.position;
+
+  // TODO: Apply this to the point displacement to roughly approx
+  // 2-way linear CCD
+  glm::vec3 avgTriDisp = ((nodeB.position - nodeB.prevPosition) +
+                          (nodeC.position - nodeC.prevPosition) +
+                          (nodeD.position - nodeD.prevPosition)) /
+                         3.0f;
+  glm::vec3 prevPoint = nodeA.prevPosition + avgTriDisp;
+
+  glm::vec3 bc = nodeC.position - nodeB.position;
+  glm::vec3 bd = nodeD.position - nodeB.position;
+  glm::vec3 ba0 = prevPoint - nodeB.position;
+  glm::vec3 ba1 = nodeA.position - nodeB.position;
+  this->n = glm::normalize(glm::cross(bc, bd));
+
+  float ba0_n = glm::dot(ba0, n);
+  float ba1_n = glm::dot(ba1, n);
+
+  glm::vec3 lineSegment = nodeA.position - prevPoint;
+  float lineLength = glm::length(lineSegment);
+
+  glm::vec3 disp;
+  float thickness = 1.0f;
+
+  if (lineLength > 0.0001f && ba0_n * ba1_n < 0.0f) {
+    // Check if the line segment crosses the triangle plane at all.
+
+    glm::vec3 dir = lineSegment / lineLength;
+
+    // if (std::abs(glm::dot(n, dir)) < 0.0001f) {
+    //   pushAway = true;
+    // } else {
+    glm::vec3 barycentricCoords = glm::inverse(glm::mat3(bc, bd, dir)) * ba1;
+
+    if ((0.0 > barycentricCoords.x) || (barycentricCoords.x > 1.0) ||
+        (0.0 > barycentricCoords.y) || (barycentricCoords.y > 1.0) ||
+        (barycentricCoords.x + barycentricCoords.y > 1.0)) {
+      return;
+    }
+
+    // glm::vec3 impactPos = nodeA.prevPosition + barycentricCoords.z *
+    // dir;
+    disp = -(barycentricCoords.z + thickness) * dir;
+    // }
+  } else {
+    if (std::abs(ba1_n) >= thickness) {
+      return;
+    }
+
+    glm::vec3 barycentricCoords = glm::inverse(glm::mat3(bc, bd, n)) * ba1;
+
+    if ((0.0 > barycentricCoords.x) || (barycentricCoords.x > 1.0) ||
+        (0.0 > barycentricCoords.y) || (barycentricCoords.y > 1.0) ||
+        (barycentricCoords.x + barycentricCoords.y > 1.0)) {
+      return;
+    }
+
+    if (ba1_n < 0.0) {
+      disp = -(thickness + ba1_n) * n;
+    } else {
+      disp = (thickness - ba1_n) * n;
+    }
+  }
+
+  float wSum = nodeA.invMass + nodeB.invMass + nodeC.invMass + nodeD.invMass;
+
+  this->projectedPositions[0] += disp * nodeA.invMass / wSum;
+  this->projectedPositions[1] -= disp * nodeB.invMass / wSum;
+  this->projectedPositions[2] -= disp * nodeC.invMass / wSum;
+  this->projectedPositions[3] -= disp * nodeD.invMass / wSum;
+
+  this->colliding = true;
+}
+
+void PointTriangleCollisionConstraint::setupCollisionMatrix(
+    Eigen::SparseMatrix<float>& systemMatrix) const {
+  systemMatrix.coeffRef(nodeIds[0], nodeIds[0]) += this->w;
+  systemMatrix.coeffRef(nodeIds[1], nodeIds[1]) += this->w;
+  systemMatrix.coeffRef(nodeIds[2], nodeIds[2]) += this->w;
+  systemMatrix.coeffRef(nodeIds[3], nodeIds[3]) += this->w;
+}
+
+void PointTriangleCollisionConstraint::setupGlobalForceVector(
+    Eigen::MatrixXf& forceVector) const {
+  // TODO: Do we need to declar no alias for projectedPositions or nodeIds??
+
+  forceVector.coeffRef(nodeIds[0], 0) += this->w * projectedPositions[0].x;
+  forceVector.coeffRef(nodeIds[0], 1) += this->w * projectedPositions[0].y;
+  forceVector.coeffRef(nodeIds[0], 2) += this->w * projectedPositions[0].z;
+
+  forceVector.coeffRef(nodeIds[1], 0) += this->w * projectedPositions[1].x;
+  forceVector.coeffRef(nodeIds[1], 1) += this->w * projectedPositions[1].y;
+  forceVector.coeffRef(nodeIds[1], 2) += this->w * projectedPositions[1].z;
+
+  forceVector.coeffRef(nodeIds[2], 0) += this->w * projectedPositions[2].x;
+  forceVector.coeffRef(nodeIds[2], 1) += this->w * projectedPositions[2].y;
+  forceVector.coeffRef(nodeIds[2], 2) += this->w * projectedPositions[2].z;
+
+  forceVector.coeffRef(nodeIds[3], 0) += this->w * projectedPositions[3].x;
+  forceVector.coeffRef(nodeIds[3], 1) += this->w * projectedPositions[3].y;
+  forceVector.coeffRef(nodeIds[3], 2) += this->w * projectedPositions[3].z;
+}
+
 StaticCollisionConstraint::StaticCollisionConstraint(
     const Node& node,
     const glm::vec3& projectedPosition_)
-    : nodeId(node.id), 
-      projectedPosition(projectedPosition_),
-      n(0.0f) {
+    : nodeId(node.id), projectedPosition(projectedPosition_), n(0.0f) {
   glm::vec3 diff = projectedPosition - node.position;
   float dist = glm::length(diff);
   if (dist > 0.00001f) {

--- a/Src/CollisionConstraint.cpp
+++ b/Src/CollisionConstraint.cpp
@@ -24,19 +24,26 @@ CollisionConstraint::CollisionConstraint(
 void CollisionConstraint::setupCollisionMatrix(
     Eigen::SparseMatrix<float>& systemMatrix) const {
   systemMatrix.coeffRef(nodeIds[0], nodeIds[0]) += this->w;
-  systemMatrix.coeffRef(nodeIds[1], nodeIds[1]) += this->w;
+  systemMatrix.coeffRef(nodeIds[1], nodeIds[1]) += this->w;  
 }
 
 void CollisionConstraint::setupGlobalForceVector(
-    Eigen::MatrixXf& forceVector) const {
+    Eigen::MatrixXf& forceVector,
+    uint32_t threadId,
+    uint32_t threadCount) const {
   // TODO: Do we need to declar no alias for projectedPositions or nodeIds??
-  forceVector.coeffRef(nodeIds[0], 0) += this->w * projectedPositions[0].x;
-  forceVector.coeffRef(nodeIds[0], 1) += this->w * projectedPositions[0].y;
-  forceVector.coeffRef(nodeIds[0], 2) += this->w * projectedPositions[0].z;
 
-  forceVector.coeffRef(nodeIds[1], 0) += this->w * projectedPositions[1].x;
-  forceVector.coeffRef(nodeIds[1], 1) += this->w * projectedPositions[1].y;
-  forceVector.coeffRef(nodeIds[1], 2) += this->w * projectedPositions[1].z;
+  if (threadId == nodeIds[0] % threadCount) {
+    forceVector.coeffRef(nodeIds[0], 0) += this->w * projectedPositions[0].x;
+    forceVector.coeffRef(nodeIds[0], 1) += this->w * projectedPositions[0].y;
+    forceVector.coeffRef(nodeIds[0], 2) += this->w * projectedPositions[0].z;
+  }
+
+  if (threadId == nodeIds[1] % threadCount) {
+    forceVector.coeffRef(nodeIds[1], 0) += this->w * projectedPositions[1].x;
+    forceVector.coeffRef(nodeIds[1], 1) += this->w * projectedPositions[1].y;
+    forceVector.coeffRef(nodeIds[1], 2) += this->w * projectedPositions[1].z;
+  }
 }
 
 StaticCollisionConstraint::StaticCollisionConstraint(

--- a/Src/CollisionDetection.cpp
+++ b/Src/CollisionDetection.cpp
@@ -142,12 +142,13 @@ std::optional<float> linearCCD(
     return t;
 
   } else {
+    // return std::nullopt;
     // Linear CCD failed, test if the point is closer than a desired thickness
     // perpendicular to the triangle normal _at the end of the interval_.
     glm::vec3 n = glm::normalize(glm::cross(ab1, ac1));
 
     // TODO: Should we consider points _behind_ the triangle??
-    float thickness = 0.25f;
+    float thickness = 0.4f;
     float nDotP = glm::dot(n, ap1);
     if (nDotP >= 0.0f && nDotP < thickness) {
       glm::vec3 barycentricCoords = glm::inverse(glm::mat3(ab1, ac1, n)) * ap1;

--- a/Src/CollisionDetection.cpp
+++ b/Src/CollisionDetection.cpp
@@ -116,45 +116,9 @@ std::optional<float> pointTriangleCCD(
   float nDotP0 = glm::dot(n0, ap0);
   float nDotP1 = glm::dot(n1, ap1);
 
-  glm::vec3 apd = ap1 - ap0;
-  glm::vec3 abd = ab1 - ab0;
-  glm::vec3 acd = ac1 - ac0;
-
-  std::optional<float> t = std::nullopt;
-  if (nDotP0 * nDotP1 < 0.0f) { 
-    // Look for a ray-plane intersection throughout the interval
-    CubicExpression expression{};
-    expandTerm(ap0.x, ab0.y, ac0.z, apd.x, abd.y, acd.z, expression);
-    expandTerm(-ap0.x, ac0.y, ab0.z, -apd.x, acd.y, abd.z, expression);
-    expandTerm(-ab0.x, ap0.y, ac0.z, -abd.x, apd.y, acd.z, expression);
-    expandTerm(ab0.x, ac0.y, ap0.z, abd.x, acd.y, apd.z, expression);
-    expandTerm(ac0.x, ap0.y, ab0.z, acd.x, apd.y, abd.z, expression);
-    expandTerm(-ac0.x, ab0.y, ap0.z, -acd.x, abd.y, apd.z, expression);
-
-    t = expression.findRootInInterval();
-  }
-
-  if (t) {
-    // Now that we have a t-value for the ray-plane intersection, check if
-    // the ray hits the triangle particularly
-    glm::vec3 apt = ap0 + *t * apd;
-    glm::vec3 abt = ab0 + *t * abd;
-    glm::vec3 act = ac0 + *t * acd;
-
-    glm::vec3 n = glm::normalize(glm::cross(abt, act));
-
-    glm::vec3 barycentricCoords = glm::inverse(glm::mat3(abt, act, n)) * apt;
-
-    if ((0.0 > barycentricCoords.x) || (barycentricCoords.x > 1.0) ||
-        (0.0 > barycentricCoords.y) || (barycentricCoords.y > 1.0) ||
-        (barycentricCoords.x + barycentricCoords.y > 1.0)) {
-      return std::nullopt;
-    }
-
-    return t;
-  } else {
-    // Linear CCD failed, test if the point is closer than a desired thickness
-    // perpendicular to the triangle normal _at the end of the interval_.
+  if (nDotP0 * nDotP1 >= 0.0f) {
+    // The point never crosses the plane of the triangle. We still consider it
+    // to be colliding if it is within the thickness.
 
     // TODO: Should we consider points _behind_ the triangle??
     float thickness = 0.1f;
@@ -172,6 +136,45 @@ std::optional<float> pointTriangleCCD(
 
     return std::nullopt;
   }
+
+  glm::vec3 apd = ap1 - ap0;
+  glm::vec3 abd = ab1 - ab0;
+  glm::vec3 acd = ac1 - ac0;
+
+  // Look for a ray-plane intersection throughout the interval
+  CubicExpression expression{};
+  expandTerm(ap0.x, ab0.y, ac0.z, apd.x, abd.y, acd.z, expression);
+  expandTerm(-ap0.x, ac0.y, ab0.z, -apd.x, acd.y, abd.z, expression);
+  expandTerm(-ab0.x, ap0.y, ac0.z, -abd.x, apd.y, acd.z, expression);
+  expandTerm(ab0.x, ac0.y, ap0.z, abd.x, acd.y, apd.z, expression);
+  expandTerm(ac0.x, ap0.y, ab0.z, acd.x, apd.y, abd.z, expression);
+  expandTerm(-ac0.x, ab0.y, ap0.z, -acd.x, abd.y, apd.z, expression);
+
+  std::optional<float> t = expression.findRootInInterval();
+
+  if (!t) {
+    // CCD failed to find a point-plane intersection. Static collision has
+    // already previously failed.
+    return std::nullopt;
+  }
+
+  // Now that we have a t-value for the ray-plane intersection, check if
+  // the ray hits the triangle particularly
+  glm::vec3 apt = ap0 + *t * apd;
+  glm::vec3 abt = ab0 + *t * abd;
+  glm::vec3 act = ac0 + *t * acd;
+
+  glm::vec3 n = glm::normalize(glm::cross(abt, act));
+
+  glm::vec3 barycentricCoords = glm::inverse(glm::mat3(abt, act, n)) * apt;
+
+  if ((0.0 > barycentricCoords.x) || (barycentricCoords.x > 1.0) ||
+      (0.0 > barycentricCoords.y) || (barycentricCoords.y > 1.0) ||
+      (barycentricCoords.x + barycentricCoords.y > 1.0)) {
+    return std::nullopt;
+  }
+
+  return t;
 }
 
 std::optional<float> edgeEdgeCCD(
@@ -183,7 +186,71 @@ std::optional<float> edgeEdgeCCD(
     const glm::vec3& ad1) {
   // TODO: Conservative test for early exit??
   // Find the shortest distance between two lines
-  
+  {
+    glm::vec3 cd1 = ad1 - ac1;
+
+    float abMagSq = glm::dot(ab1, ab1);
+    float cdMagSq = glm::dot(cd1, cd1);
+    float abDotCd = glm::dot(ab1, cd1);
+
+    float acDotAb = glm::dot(ac1, ab1);
+    float acDotCd = glm::dot(ac1, cd1);
+
+    float det = abMagSq * -cdMagSq + abDotCd * abDotCd;
+    float u = 0.0f;
+    float v = 0.0f;
+    if (det != 0.0f) {
+      det = 1.0f / det;
+      float u = (acDotAb * -cdMagSq + abDotCd * acDotCd) * det;
+      float v = (abMagSq * acDotCd - acDotAb * abDotCd) * det;
+    } else {
+      float u0 = 0.0f;
+      float u1 = 1.0f;
+      float v0 = glm::dot(ac1, ab1);
+      float v1 = glm::dot(ad1, ab1);
+
+      bool flip0 = false;
+      bool flip1 = false;
+
+      if (u0 > u1) {
+        std::swap(u0, u1);
+        flip0 = true;
+      }
+
+      if (v0 > v1) {
+        std::swap(v0, v1);
+        flip1 = true;
+      }
+
+      if (u0 >= v1) {
+        u = flip0 ? 1.0f : 0.0f;
+        v = flip1 ? 0.0f : 1.0f;
+      } else if (v0 >= u1) {
+        u = flip0 ? 0.0f : 1.0f;
+        v = flip1 ? 1.0f : 0.0f;
+      } else {
+        float mid = (u0 > v0) ? (u0 + v1) * 0.5f : (v0 + u1) * 0.5f;
+        u = (u0 == u1) ? 0.5f : (mid - u0) / (u1 - u0);
+        v = (v0 == v1) ? 0.5f : (mid - v0) / (v1 - v0);
+      }
+    }
+
+    u = glm::clamp(u, 0.0f, 1.0f);
+    v = glm::clamp(v, 0.0f, 1.0f);
+
+    glm::vec3 q0 = glm::mix(glm::vec3(0.0f), ab1, u);
+    glm::vec3 q1 = glm::mix(ac1, ad1, v);
+
+    glm::vec3 n = q0 - q1;
+    float dist = glm::length(n);
+    n /= dist;
+
+    float thickness = 0.5f;
+    if (dist < thickness) {
+      return 1.0f;
+    }
+  }
+
   glm::vec3 abd = ab1 - ab0;
   glm::vec3 acd = ac1 - ac0;
   glm::vec3 add = ad1 - ad0;
@@ -197,10 +264,33 @@ std::optional<float> edgeEdgeCCD(
   expandTerm(ad0.x, ab0.y, ac0.z, add.x, abd.y, acd.z, expression);
   expandTerm(-ad0.x, ac0.y, ab0.z, -add.x, acd.y, abd.z, expression);
 
-  return expression.findRootInInterval();
+  std::optional<float> t = expression.findRootInInterval();
 
-  // TODO: Fallback to static collision detection when the above fails or
-  // there is no intersection but the edges are within some epsilon
+  // Check
+  if (!t) {
+    return std::nullopt;
+  }
+
+  glm::vec3 abt = ab0 + abd * *t;
+  glm::vec3 act = ac0 + acd * *t;
+  glm::vec3 adt = ad0 + add * *t;
+  glm::vec3 cdt = adt - act;
+
+  glm::vec3 nt = glm::normalize(glm::cross(abt, cdt));
+
+  // Check for 2D line intersection at time t
+
+  // abt * u = act + cdt * v 
+  // abt * u - cdt * v = act
+  // [abt, -cdt] [u,v]t = act
+  glm::mat3 M(abt, -cdt, nt);
+  glm::vec2 uv = glm::inverse(M) * act;
+
+  if (uv.x < 0.0f || uv.x > 1.0f || uv.y < 0.0f || uv.y > 1.0f) {
+    return std::nullopt;
+  }
+
+  return t;
 }
 } // namespace CollisionDetection
 } // namespace Pies

--- a/Src/CollisionDetection.cpp
+++ b/Src/CollisionDetection.cpp
@@ -1,0 +1,148 @@
+#include "CollisionDetection.h"
+
+#include <unsupported/Eigen/Polynomials>
+
+#include <algorithm>
+#include <optional>
+
+namespace {
+struct CubicExpression {
+  float cubicCoeff;
+  float quadCoeff;
+  float linearCoeff;
+  float constCoeff;
+
+  float eval(float t) const {
+    float t2 = t * t;
+    return cubicCoeff * t2 * t + quadCoeff * t2 + linearCoeff * t + constCoeff;
+  }
+
+  std::optional<float> findRootInInterval() const {
+    // TODO: Epsilon 0 check??
+    if (cubicCoeff == 0.0f) {
+      if (quadCoeff == 0.0f) {
+        if (linearCoeff == 0.0f) {
+          if (constCoeff == 0.0f) {
+            return 0.0f;
+          }
+
+          return std::nullopt;
+        }
+
+        float t = -constCoeff / linearCoeff;
+        if (t >= 0.0f && t <= 1.0f) {
+          return t;
+        }
+
+        return std::nullopt;
+      } else {
+        // Quadratic expression
+        float b2_4ac =
+            linearCoeff * linearCoeff - 4.0f * quadCoeff * constCoeff;
+        if (b2_4ac < 0.0f) {
+          // Imaginary roots
+          return std::nullopt;
+        }
+
+        float sqrtb2_4ac = sqrt(b2_4ac);
+
+        float t = (-linearCoeff - sqrtb2_4ac) / (2.0f * quadCoeff);
+        if (t > 1.0f) {
+          return std::nullopt;
+        } else if (t < 0.0f) {
+          // Consider the second root if the first root falls before the
+          // interval.
+          t = (-linearCoeff + sqrtb2_4ac) / (2.0f * quadCoeff);
+        }
+
+        if (t >= 0.0f && t <= 1.0f) {
+          return t;
+        }
+
+        return std::nullopt;
+      }
+    }
+
+    Eigen::Vector4f coeffs(constCoeff, linearCoeff, quadCoeff, cubicCoeff);
+    Eigen::PolynomialSolver<float, 3> solver(coeffs);
+    const Eigen::PolynomialSolver<float, 3>::RootsType& roots = solver.roots();
+
+    std::optional<float> validRoot = std::nullopt;
+    for (uint32_t i = 0; i < 3; ++i) {
+      // Is it better to just check if the imaginary part is eq to 0?
+      if (std::abs(roots[i].imag()) < 0.0000001f && roots[i].real() >= 0.0f &&
+          roots[i].real() <= 1.0f) {
+        if (!validRoot || roots[i].real() < *validRoot) {
+          validRoot = roots[i].real();
+        }
+      }
+    }
+
+    return validRoot;
+  }
+};
+
+// TODO: Better name??
+inline void expandTerm(
+    float a0,
+    float b0,
+    float c0,
+    float ad,
+    float bd,
+    float cd,
+    CubicExpression& expression) {
+  expression.cubicCoeff += ad * bd * cd;
+  expression.quadCoeff += ad * bd * c0 + a0 * bd * cd + ad * b0 * cd;
+  expression.linearCoeff += ad * b0 * c0 + a0 * bd * c0 + a0 * b0 * cd;
+  expression.constCoeff += a0 * b0 * c0;
+}
+} // namespace
+
+namespace Pies {
+namespace CollisionDetection {
+  
+std::optional<float> linearCCD(
+    const glm::vec3& ap0,
+    const glm::vec3& ab0,
+    const glm::vec3& ac0,
+    const glm::vec3& ap1,
+    const glm::vec3& ab1,
+    const glm::vec3& ac1) {
+  glm::vec3 apd = ap1 - ap0;
+  glm::vec3 abd = ab1 - ab0;
+  glm::vec3 acd = ac1 - ac0;
+
+  // Look for a ray-plane intersection throughout the interval
+  CubicExpression expression{};
+  expandTerm(ap0.x, ab0.y, ac0.z, apd.x, abd.y, acd.z, expression);
+  expandTerm(-ap0.x, ac0.y, ab0.z, -apd.x, acd.y, abd.z, expression);
+  expandTerm(-ab0.x, ap0.y, ac0.z, -abd.x, apd.y, acd.z, expression);
+  expandTerm(ab0.x, ac0.y, ap0.z, abd.x, acd.y, apd.z, expression);
+  expandTerm(ac0.x, ap0.y, ab0.z, acd.x, apd.y, abd.z, expression);
+  expandTerm(-ac0.x, ab0.y, ap0.z, -acd.x, abd.y, apd.z, expression);
+
+  std::optional<float> t = expression.findRootInInterval();
+  if (!t) {
+    return std::nullopt;
+  }
+
+  // Now that we have a t-value for the ray-plane intersection, check if
+  // the ray hits the triangle particularly
+  glm::vec3 apt = ap0 + *t * apd;
+  glm::vec3 abt = ab0 + *t * abd;
+  glm::vec3 act = ac0 + *t * acd;
+
+  glm::vec3 n = glm::normalize(glm::cross(abt, act));
+
+  glm::vec3 barycentricCoords = glm::inverse(glm::mat3(abt, act, n)) * apt;
+
+  if ((0.0 > barycentricCoords.x) || (barycentricCoords.x > 1.0) ||
+      (0.0 > barycentricCoords.y) || (barycentricCoords.y > 1.0) ||
+      (barycentricCoords.x + barycentricCoords.y > 1.0)) {
+    return std::nullopt;
+  }
+
+  return t;
+}
+} // namespace CollisionDetection
+} // namespace Pies

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -25,17 +25,25 @@ void DistanceConstraintProjection::operator()(
 
   float wSum = a.invMass + b.invMass;
 
-  projected[0] = a.position - disp * dir * a.invMass / wSum;
-  projected[1] = b.position + disp * dir * b.invMass / wSum;
+  projected[0] = -disp * dir;//a.position - disp * dir * a.invMass / wSum;
+  projected[1] = glm::vec3(0.0f);//b.position + disp * dir * b.invMass / wSum;
 }
 
 DistanceConstraint
 createDistanceConstraint(uint32_t id, const Node& a, const Node& b, float w) {
+  // A == B
+  Eigen::Matrix2f A;
+  //  = Eigen::Matrix2f::Zero();
+  A.coeffRef(0, 0) = 0.5f;
+  A.coeffRef(0, 1) = -0.5f;
+  A.coeffRef(1, 0) = -0.5f;
+  A.coeffRef(1, 1) = 0.5f;
+
   return DistanceConstraint(
       id,
       w,
-      Eigen::Matrix2f::Identity(),
-      Eigen::Matrix2f::Identity(),
+      A,
+      A,
       {glm::length(b.position - a.position)},
       {a.id, b.id});
 }
@@ -122,6 +130,16 @@ TetrahedralConstraint createTetrahedralConstraint(
     const Node& x2,
     const Node& x3,
     const Node& x4) {
+  
+  // A == B
+  Eigen::Matrix4f A = Eigen::Matrix4f::Zero(); 
+  A.coeffRef(1, 0) = -1.0f;
+  A.coeffRef(2, 0) = -1.0f;
+  A.coeffRef(3, 0) = -1.0f;
+
+  A.coeffRef(1, 1) = 1.0f;
+  A.coeffRef(2, 2) = 1.0f;
+  A.coeffRef(3, 3) = 1.0f;
 
   glm::mat3 Q(
       x2.position - x1.position,
@@ -131,8 +149,8 @@ TetrahedralConstraint createTetrahedralConstraint(
   return TetrahedralConstraint(
       id,
       w,
-      Eigen::Matrix4f::Identity(),
-      Eigen::Matrix4f::Identity(),
+      A,
+      A,
       {glm::inverse(Q)},
       {x1.id, x2.id, x3.id, x4.id});
 }
@@ -175,6 +193,16 @@ VolumeConstraint createVolumeConstraint(
     const Node& x2,
     const Node& x3,
     const Node& x4) {
+  // A == B
+  Eigen::Matrix4f A = Eigen::Matrix4f::Zero(); 
+  A.coeffRef(1, 0) = -1.0f;
+  A.coeffRef(2, 0) = -1.0f;
+  A.coeffRef(3, 0) = -1.0f;
+
+  A.coeffRef(1, 1) = 1.0f;
+  A.coeffRef(2, 2) = 1.0f;
+  A.coeffRef(3, 3) = 1.0f;
+
   glm::vec3 x21 = x2.position - x1.position;
   glm::vec3 x31 = x3.position - x1.position;
   glm::vec3 x41 = x4.position - x1.position;
@@ -183,8 +211,8 @@ VolumeConstraint createVolumeConstraint(
   return VolumeConstraint(
       id,
       w,
-      Eigen::Matrix4f::Identity(),
-      Eigen::Matrix4f::Identity(),
+      A,
+      A,
       {targetVolume},
       {x1.id, x2.id, x3.id, x4.id});
 }

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -20,7 +20,7 @@ void DistanceConstraintProjection::operator()(
     dir = diff / dist;
   }
 
-  float disp = glm::min(this->targetDistance - dist, 0.0f);
+  float disp = this->targetDistance - dist;//glm::min(this->targetDistance - dist, 0.0f);
 
   float wSum = a.invMass + b.invMass;
 

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -178,7 +178,7 @@ VolumeConstraint createVolumeConstraint(
   float targetVolume = glm::dot(glm::cross(x21, x31), x41) / 6.0f;
   return VolumeConstraint(
       id, 
-      k, 
+      k,
       Eigen::Matrix4f::Identity(),
       Eigen::Matrix4f::Identity(),
       {targetVolume}, 

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -20,7 +20,8 @@ void DistanceConstraintProjection::operator()(
     dir = diff / dist;
   }
 
-  float disp = this->targetDistance - dist;//glm::min(this->targetDistance - dist, 0.0f);
+  float disp = this->targetDistance -
+               dist; // glm::min(this->targetDistance - dist, 0.0f);
 
   float wSum = a.invMass + b.invMass;
 
@@ -221,10 +222,8 @@ void BendConstraintProjection::operator()(
   projected[2] = x3.position;
   projected[3] = x4.position;
 
-  glm::vec3 q3 =
-      (glm::cross(p2, n2) + (glm::cross(n1, p2) * d)) / p2Xp3_len;
-  glm::vec3 q4 =
-      (glm::cross(p2, n1) + (glm::cross(n2, p2) * d)) / p2Xp4_len;
+  glm::vec3 q3 = (glm::cross(p2, n2) + (glm::cross(n1, p2) * d)) / p2Xp3_len;
+  glm::vec3 q4 = (glm::cross(p2, n1) + (glm::cross(n2, p2) * d)) / p2Xp4_len;
   glm::vec3 q2 =
       -((glm::cross(p3, n2) + (glm::cross(n1, p3) * d)) / p2Xp3_len) -
       ((glm::cross(p4, n1) + (glm::cross(n2, p4) * d)) / p2Xp4_len);

--- a/Src/Constraints.cpp
+++ b/Src/Constraints.cpp
@@ -1,5 +1,8 @@
 #include "Constraints.h"
 
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/SVD>
 #include <glm/gtc/matrix_access.hpp>
 #include <glm/gtc/matrix_inverse.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -25,8 +28,8 @@ void DistanceConstraintProjection::operator()(
 
   float wSum = a.invMass + b.invMass;
 
-  projected[0] = -disp * dir;//a.position - disp * dir * a.invMass / wSum;
-  projected[1] = glm::vec3(0.0f);//b.position + disp * dir * b.invMass / wSum;
+  projected[0] = -disp * dir;     // a.position - disp * dir * a.invMass / wSum;
+  projected[1] = glm::vec3(0.0f); // b.position + disp * dir * b.invMass / wSum;
 }
 
 DistanceConstraint
@@ -82,45 +85,43 @@ void TetrahedralConstraintProjection::operator()(
 
   // Deformation gradient
   glm::mat3 F = P * this->Qinv;
-  glm::mat3 Ft = glm::transpose(F);
 
-  float stretchResistance = 1.0f;
-  glm::mat3 S = Ft * F;
+  Eigen::Matrix3f F_;
+  F_ << F[0][0], F[0][1], F[0][2], F[1][0], F[1][1], F[1][2], F[2][0], F[2][1],
+      F[2][2];
 
-  // Tensor of stretch and strain constraints
-  // Green - St Vernant strain formulation
-  // TODO: Use sqrt version
-  glm::mat3 C = S - glm::mat3(stretchResistance * stretchResistance);
-
-  projected[0] = x1.position;
-  projected[1] = x2.position;
-  projected[2] = x3.position;
-  projected[3] = x4.position;
-
-  // Project the constraints one after another
+  Eigen::JacobiSVD<Eigen::Matrix3f> svdF(
+      F_,
+      Eigen::ComputeFullU | Eigen::ComputeFullV);
+  Eigen::Vector3f singularValues = svdF.singularValues();
+  float omegaMin = 0.8f;
+  float omegaMax = 1.0f;
   for (uint32_t i = 0; i < 3; ++i) {
-    for (uint32_t j = 0; j <= i; ++j) {
-      glm::mat3 dCijdX =
-          glm::outerProduct(glm::column(F, j), glm::column(this->Qinv, i)) +
-          glm::outerProduct(glm::column(F, i), glm::column(this->Qinv, j));
-      glm::vec3 dCijdx1 = -glm::column(dCijdX, 0) - glm::column(dCijdX, 1) -
-                          glm::column(dCijdX, 2);
-      float denom =
-          x1.invMass * glm::dot(dCijdx1, dCijdx1) +
-          x2.invMass *
-              glm::dot(glm::column(dCijdX, 0), glm::column(dCijdX, 0)) +
-          x3.invMass *
-              glm::dot(glm::column(dCijdX, 1), glm::column(dCijdX, 1)) +
-          x4.invMass * glm::dot(glm::column(dCijdX, 2), glm::column(dCijdX, 2));
-      float lambda = C[i][j] / denom;
-
-      // Recompute F from projected positions?
-      projected[0] += -lambda * x1.invMass * dCijdx1;
-      projected[1] += -lambda * x2.invMass * glm::column(dCijdX, 0);
-      projected[2] += -lambda * x3.invMass * glm::column(dCijdX, 1);
-      projected[3] += -lambda * x4.invMass * glm::column(dCijdX, 2);
-    }
+    singularValues[i] = glm::clamp(singularValues[i], omegaMin, omegaMax);
   }
+
+  if (glm::determinant(F) < 0.0f) {
+    singularValues[2] *= -1.0f;
+  }
+
+  // The "fixed" deformation gradient
+  Eigen::Matrix3f Fhat =
+      svdF.matrixU() * singularValues.asDiagonal() * svdF.matrixV().transpose();
+  glm::mat3 P1 = glm::transpose(glm::mat3(
+      Fhat.coeff(0, 0),
+      Fhat.coeff(1, 0),
+      Fhat.coeff(2, 0),
+      Fhat.coeff(0, 1),
+      Fhat.coeff(1, 1),
+      Fhat.coeff(2, 1),
+      Fhat.coeff(0, 2),
+      Fhat.coeff(1, 2),
+      Fhat.coeff(2, 2)));
+
+  projected[0] = glm::vec3(0.0f);
+  projected[1] = P1[0];
+  projected[2] = P1[1];
+  projected[3] = P1[2];
 }
 
 TetrahedralConstraint createTetrahedralConstraint(
@@ -130,28 +131,52 @@ TetrahedralConstraint createTetrahedralConstraint(
     const Node& x2,
     const Node& x3,
     const Node& x4) {
-  
-  // A == B
-  Eigen::Matrix4f A = Eigen::Matrix4f::Zero(); 
-  A.coeffRef(1, 0) = -1.0f;
-  A.coeffRef(2, 0) = -1.0f;
-  A.coeffRef(3, 0) = -1.0f;
 
-  A.coeffRef(1, 1) = 1.0f;
-  A.coeffRef(2, 2) = 1.0f;
-  A.coeffRef(3, 3) = 1.0f;
+  // Converts world positions to differential coords
+  Eigen::Matrix<float, 3, 4> worldToDiff = Eigen::Matrix<float, 3, 4>::Zero();
+  worldToDiff.coeffRef(0, 0) = -1.0f;
+  worldToDiff.coeffRef(1, 0) = -1.0f;
+  worldToDiff.coeffRef(2, 0) = -1.0f;
 
-  glm::mat3 Q(
+  worldToDiff.coeffRef(0, 1) = 1.0f;
+  worldToDiff.coeffRef(1, 2) = 1.0f;
+  worldToDiff.coeffRef(2, 3) = 1.0f;
+
+  // Converts barycentric coords to world differential cords
+  glm::mat3 baryToDiff(
       x2.position - x1.position,
       x3.position - x1.position,
       x4.position - x1.position);
+  glm::mat3 diffToBary = glm::inverse(baryToDiff);
+
+  Eigen::Matrix3f diffToBary_;
+  diffToBary_ << 
+      diffToBary[0][0], diffToBary[0][1], diffToBary[0][2],
+      diffToBary[1][0], diffToBary[1][1], diffToBary[1][2],
+      diffToBary[2][0], diffToBary[2][1], diffToBary[2][2];
+      
+  Eigen::Matrix<float, 3, 4> A_ = diffToBary_ * worldToDiff;
+  Eigen::Matrix4f A = Eigen::Matrix4f::Zero();
+  // A.coeffRef(1, 0) = -1.0f;
+  // A.coeffRef(2, 0) = -1.0f;
+  // A.coeffRef(3, 0) = -1.0f;
+
+  // A.coeffRef(1, 1) = 1.0f;
+  // A.coeffRef(2, 2) = 1.0f;
+  // A.coeffRef(3, 3) = 1.0f;
+
+
+  A.row(0) << 0.0f, 0.0f, 0.0f, 0.0f;
+  A.row(1) = A_.row(0);
+  A.row(2) = A_.row(1);
+  A.row(3) = A_.row(2);
 
   return TetrahedralConstraint(
       id,
       w,
       A,
-      A,
-      {glm::inverse(Q)},
+      Eigen::Matrix4f::Identity(),
+      {baryToDiff, diffToBary},
       {x1.id, x2.id, x3.id, x4.id});
 }
 
@@ -194,7 +219,7 @@ VolumeConstraint createVolumeConstraint(
     const Node& x3,
     const Node& x4) {
   // A == B
-  Eigen::Matrix4f A = Eigen::Matrix4f::Zero(); 
+  Eigen::Matrix4f A = Eigen::Matrix4f::Zero();
   A.coeffRef(1, 0) = -1.0f;
   A.coeffRef(2, 0) = -1.0f;
   A.coeffRef(3, 0) = -1.0f;

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -47,7 +47,7 @@ void Solver::createTetBox(
   Grid grid{3, 3, 3};
 
   if (hinged) {
-    grid = Grid{15, 2, 2};
+    grid = Grid{15, 15, 2};
   }
 
   size_t currentNodeCount = this->_nodes.size();
@@ -563,7 +563,7 @@ void Solver::createSheet(
     float scale,
     float mass,
     float stiffness) {
-  Grid grid{4, 4, 1};
+  Grid grid{16, 16, 1};
 
   size_t currentNodeCount = this->_nodes.size();
   size_t currentDistConstraintsCount = this->_distanceConstraints.size();

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -72,7 +72,7 @@ void Solver::createTetBox(
         node.position = scale * glm::vec3(i, j, k) + translation;
         node.prevPosition = node.position;
         node.velocity = initialVelocity;
-        node.radius = 0.5f * scale;
+        node.radius = 0.95f * 0.5f * scale;
         node.invMass = 1.0f / mass;
 
         if (hinged && i == 0) { //} && j == 0) {
@@ -191,102 +191,84 @@ void Solver::createTetBox(
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j, grid.depth - 1}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, j + 1, grid.depth - 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, grid.depth - 1}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, j + 1, grid.depth - 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, j + 1, grid.depth - 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j + 1, grid.depth - 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, j + 1, grid.depth - 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, grid.depth - 1})});
     }
   }
 
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, 0, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, 0, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, 0, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, 0, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, 0, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i, 0, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, grid.height - 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, grid.height - 1, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, grid.height - 1, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, grid.height - 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1})});
     }
   }
 
   for (uint32_t j = 0; j < grid.height - 1; ++j) {
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j + 1, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {grid.width - 1, j + 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}),
+           grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j + 1, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {grid.width - 1, j + 1, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {grid.width - 1, j + 1, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {grid.width - 1, j + 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k + 1})});
     }
   }
 
@@ -422,102 +404,85 @@ void Solver::createBox(
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j, grid.depth - 1}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, j + 1, grid.depth - 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, grid.depth - 1}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, j + 1, grid.depth - 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, j + 1, grid.depth - 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j + 1, grid.depth - 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, j + 1, grid.depth - 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, grid.depth - 1})});
     }
   }
 
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, 0, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, 0, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, 0, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, 0, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, 0, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, 0, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i, 0, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, grid.height - 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, grid.height - 1, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {i + 1, grid.height - 1, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, grid.height - 1, k + 1}),
+
+           grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1})});
     }
   }
 
   for (uint32_t j = 0; j < grid.height - 1; ++j) {
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j + 1, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {grid.width - 1, j + 1, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}),
+           grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j + 1, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {grid.width - 1, j + 1, k + 1})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}));
-      this->_triangles.push_back(grid.gridIdToNodeId(
-          currentNodeCount,
-          {grid.width - 1, j + 1, k + 1}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k + 1}));
+          {grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {grid.width - 1, j + 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k + 1})});
     }
   }
 
@@ -557,7 +522,7 @@ void Solver::createSheet(
     float scale,
     float mass,
     float stiffness) {
-  Grid grid{12, 12, 1};
+  Grid grid{16, 16, 1};
 
   size_t currentNodeCount = this->_nodes.size();
   size_t currentDistConstraintsCount = this->_distanceConstraints.size();
@@ -582,7 +547,7 @@ void Solver::createSheet(
       node.radius = 0.5f * scale;
       node.invMass = 1.0f / mass;
 
-      if (i == 0 || i == (grid.width - 1)) {
+      if (i == 0 || i == (grid.width - 1) || j == 0 || j == (grid.height - 1)) {
         this->_positionConstraints.push_back(
             createPositionConstraint(this->_constraintId++, node, stiffness));
       }
@@ -639,18 +604,14 @@ void Solver::createSheet(
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
 
       this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}));
-      this->_triangles.push_back(
-          grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0}));
+          {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0})});
     }
   }
 
@@ -695,6 +656,8 @@ void Solver::createShapeMatchingBox(
     float w) {
   Grid grid{countX, countY, countZ};
 
+  scale = 0.5f;
+
   size_t currentNodeCount = this->_nodes.size();
 
   glm::vec3 boxColor = randColor();
@@ -715,7 +678,7 @@ void Solver::createShapeMatchingBox(
         node.prevPosition = node.position;
         node.velocity = glm::vec3(0.0f);
         node.radius = 0.5f * scale;
-        node.invMass = 1.0f;
+        node.invMass = 1.0f /10.0f;
 
         // if (i == 0 && j == 0) {
         //   this->_positionConstraints.push_back(

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -47,7 +47,7 @@ void Solver::createTetBox(
   Grid grid{3, 3, 3};
 
   if (hinged) {
-    grid = Grid{15, 15, 2};
+    grid = Grid{10, 2, 10};
   }
 
   size_t currentNodeCount = this->_nodes.size();
@@ -75,10 +75,10 @@ void Solver::createTetBox(
         node.radius = 0.95f * 0.5f * scale;
         node.invMass = 1.0f / mass;
 
-        if (hinged && i == 0) { //} && j == 0) {
-          this->_positionConstraints.push_back(
-              createPositionConstraint(this->_constraintId++, node, stiffness));
-        }
+        // if (hinged && i == 0) { //} && j == 0) {
+        //   this->_positionConstraints.push_back(
+        //       createPositionConstraint(this->_constraintId++, node, stiffness));
+        // }
       }
     }
   }

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -37,6 +37,43 @@ struct Grid {
 };
 } // namespace
 
+void Solver::addNodes(
+    const std::vector<glm::vec3>& vertices) {
+  
+  // TODO: parameterize more of these
+  float mass = 1.0f;
+  float radius = 0.5f;
+  glm::vec3 initialVelocity(0.0f);
+
+  glm::vec3 color = randColor();
+  float roughness = randf();
+  float metallic = static_cast<float>(std::rand() % 2);
+
+  size_t currentNodeCount = this->_nodes.size();
+  this->_nodes.reserve(
+      currentNodeCount + vertices.size());
+  for (uint32_t i = 0; i < static_cast<uint32_t>(vertices.size()); ++i) {
+    Node& node = this->_nodes.emplace_back();
+    node.id = currentNodeCount + i;
+    node.position = vertices[i];
+    node.prevPosition = node.position;
+    node.velocity = initialVelocity;
+    node.radius = radius;
+    node.invMass = 1.0f / mass;
+  }
+
+  this->_vertices.resize(this->_nodes.size());
+  for (size_t i = currentNodeCount; i < this->_nodes.size(); ++i) {
+    this->_vertices[i].position = this->_nodes[i].position;
+    this->_vertices[i].radius = this->_nodes[i].radius;
+    this->_vertices[i].baseColor = color;
+    this->_vertices[i].roughness = roughness;
+    this->_vertices[i].metallic = metallic;
+  }
+
+  this->renderStateDirty = true;
+}
+
 void Solver::createTetBox(
     const glm::vec3& translation,
     float scale,

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -1,6 +1,8 @@
 #include "Node.h"
 #include "Solver.h"
 
+#include <tetgen.h>
+
 #include <cstdlib>
 
 namespace Pies {
@@ -37,9 +39,8 @@ struct Grid {
 };
 } // namespace
 
-void Solver::addNodes(
-    const std::vector<glm::vec3>& vertices) {
-  
+void Solver::addNodes(const std::vector<glm::vec3>& vertices) {
+
   // TODO: parameterize more of these
   float mass = 1.0f;
   float radius = 0.5f;
@@ -50,8 +51,7 @@ void Solver::addNodes(
   float metallic = static_cast<float>(std::rand() % 2);
 
   size_t currentNodeCount = this->_nodes.size();
-  this->_nodes.reserve(
-      currentNodeCount + vertices.size());
+  this->_nodes.reserve(currentNodeCount + vertices.size());
   for (uint32_t i = 0; i < static_cast<uint32_t>(vertices.size()); ++i) {
     Node& node = this->_nodes.emplace_back();
     node.id = currentNodeCount + i;
@@ -64,6 +64,101 @@ void Solver::addNodes(
 
   this->_vertices.resize(this->_nodes.size());
   for (size_t i = currentNodeCount; i < this->_nodes.size(); ++i) {
+    this->_vertices[i].position = this->_nodes[i].position;
+    this->_vertices[i].radius = this->_nodes[i].radius;
+    this->_vertices[i].baseColor = color;
+    this->_vertices[i].roughness = roughness;
+    this->_vertices[i].metallic = metallic;
+  }
+
+  this->renderStateDirty = true;
+}
+
+void Solver::addTriMeshVolume(
+    const std::vector<glm::vec3>& vertices,
+    const std::vector<uint32_t>& indices,
+    float w) {
+
+  // TODO: parameterize more of these
+  float mass = 1.0f;
+  float radius = 0.5f;
+  glm::vec3 initialVelocity(0.0f);
+
+  glm::vec3 color = randColor();
+  float roughness = randf();
+  float metallic = static_cast<float>(std::rand() % 2);
+
+  tetgenio tetgenInput{};
+  tetgenInput.numberofpoints = static_cast<int>(vertices.size());
+  tetgenInput.pointlist = new double[vertices.size() * 3];
+  for (size_t i = 0; i < vertices.size(); ++i) {
+    const glm::vec3& vertex = vertices[i];
+    tetgenInput.pointlist[3 * i + 0] = vertex.x;
+    tetgenInput.pointlist[3 * i + 1] = vertex.y;
+    tetgenInput.pointlist[3 * i + 2] = vertex.z;
+  }
+
+  // TODO: Is there any advantage to _not_ treating each triangle as its own
+  // face??
+  tetgenInput.numberoffacets = static_cast<int>(indices.size() / 3);
+  tetgenInput.facetlist = new tetgenio::facet[tetgenInput.numberoffacets];
+  for (int i = 0; i < tetgenInput.numberoffacets; ++i) {
+    tetgenio::facet& face = tetgenInput.facetlist[i];
+    face.numberofpolygons = 1;
+    face.polygonlist = new tetgenio::polygon[1];
+
+    face.polygonlist[0].numberofvertices = 3;
+    face.polygonlist[0].vertexlist = new int[3];
+    face.polygonlist[0].vertexlist[0] = indices[3 * i + 0];
+    face.polygonlist[0].vertexlist[1] = indices[3 * i + 1];
+    face.polygonlist[0].vertexlist[2] = indices[3 * i + 2];
+
+    face.numberofholes = 0;
+    face.holelist = nullptr;
+  }
+
+  tetgenio tetgenOutput{};
+  tetgenbehavior behavior{};
+
+  tetrahedralize(&behavior, &tetgenInput, &tetgenOutput);
+
+  // tetgenOutput.tetrahedronlist()
+  size_t existingNodesCount = this->_nodes.size();
+  size_t existingTetsCount = this->_tetConstraints.size();
+
+  this->_nodes.reserve(existingNodesCount + tetgenOutput.numberofpoints);
+  for (int i = 0; i < tetgenOutput.numberofpoints; i++) {
+    Node& node = this->_nodes.emplace_back();
+    node.id = existingNodesCount + i;
+    node.position = glm::vec3(
+        static_cast<float>(tetgenOutput.pointlist[3 * i + 0]),
+        static_cast<float>(tetgenOutput.pointlist[3 * i + 1]),
+        static_cast<float>(tetgenOutput.pointlist[3 * i + 2]));
+    node.prevPosition = node.position;
+    node.velocity = initialVelocity;
+    node.radius = radius;
+    node.invMass = 1.0f / mass;
+  }
+
+  this->_tetConstraints.reserve(
+      existingTetsCount + tetgenOutput.numberoftetrahedra);
+  for (int i = 0; i < tetgenOutput.numberoftetrahedra; ++i) {
+    int v1 = tetgenOutput.tetrahedronlist[4 * i + 0];
+    int v2 = tetgenOutput.tetrahedronlist[4 * i + 1];
+    int v3 = tetgenOutput.tetrahedronlist[4 * i + 2];
+    int v4 = tetgenOutput.tetrahedronlist[4 * i + 3];
+
+    this->_tetConstraints.push_back(createTetrahedralConstraint(
+        this->_constraintId++,
+        w,
+        this->_nodes[existingNodesCount + v1],
+        this->_nodes[existingNodesCount + v2],
+        this->_nodes[existingNodesCount + v3],
+        this->_nodes[existingNodesCount + v4]));
+  }
+
+  this->_vertices.resize(this->_nodes.size());
+  for (size_t i = existingNodesCount; i < this->_nodes.size(); ++i) {
     this->_vertices[i].position = this->_nodes[i].position;
     this->_vertices[i].radius = this->_nodes[i].radius;
     this->_vertices[i].baseColor = color;
@@ -339,10 +434,7 @@ void Solver::createTetBox(
   this->renderStateDirty = true;
 }
 
-void Solver::createBox(
-    const glm::vec3& translation,
-    float scale,
-    float w) {
+void Solver::createBox(const glm::vec3& translation, float scale, float w) {
   Grid grid{5, 5, 5};
 
   size_t currentNodeCount = this->_nodes.size();
@@ -722,7 +814,10 @@ void Solver::createSheet(
   this->renderStateDirty = true;
 }
 
-void Solver::createBendSheet(const glm::vec3& translation, float scale, float w) {
+void Solver::createBendSheet(
+    const glm::vec3& translation,
+    float scale,
+    float w) {
   Grid grid{10, 10, 1};
 
   size_t currentNodeCount = this->_nodes.size();
@@ -736,121 +831,118 @@ void Solver::createBendSheet(const glm::vec3& translation, float scale, float w)
   float boxMetallic = static_cast<float>(std::rand() % 2);
 
   // Add nodes in a grid
-  this->_nodes.reserve(
-      currentNodeCount + grid.width * grid.height);
+  this->_nodes.reserve(currentNodeCount + grid.width * grid.height);
   for (uint32_t i = 0; i < grid.width; ++i) {
     for (uint32_t j = 0; j < grid.height; ++j) {
-        uint32_t nodeId = grid.gridIdToNodeId(currentNodeCount, {i, j, 0});
+      uint32_t nodeId = grid.gridIdToNodeId(currentNodeCount, {i, j, 0});
 
-        Node& node = this->_nodes.emplace_back();
-        node.id = nodeId;
-        node.position = scale * glm::vec3(i, 0, j) + translation;
-        node.prevPosition = node.position;
-        node.velocity = glm::vec3(0.0f);
-        node.radius = 0.5f * scale;
-        node.invMass = 1.0f;
+      Node& node = this->_nodes.emplace_back();
+      node.id = nodeId;
+      node.position = scale * glm::vec3(i, 0, j) + translation;
+      node.prevPosition = node.position;
+      node.velocity = glm::vec3(0.0f);
+      node.radius = 0.5f * scale;
+      node.invMass = 1.0f;
 
-        if (i < 3) {
-          this->_positionConstraints.push_back(
-              createPositionConstraint(this->_constraintId++, node, w));
-        }
+      if (i < 3) {
+        this->_positionConstraints.push_back(
+            createPositionConstraint(this->_constraintId++, node, w));
+      }
     }
   }
 
   // Add distance constraints in each grid cell
   this->_distanceConstraints.reserve(
-      currentDistConstraintsCount +
-      8 * (grid.width - 1) * (grid.height - 1));
+      currentDistConstraintsCount + 8 * (grid.width - 1) * (grid.height - 1));
   for (uint32_t i = 0; i < grid.width; ++i) {
     for (uint32_t j = 0; j < grid.height; ++j) {
-        uint32_t node00 = grid.gridIdToNodeId(currentNodeCount, {i, j, 0});
-        uint32_t node01 = grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0});
-        uint32_t node10 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0});
-        uint32_t node11 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0});
+      uint32_t node00 = grid.gridIdToNodeId(currentNodeCount, {i, j, 0});
+      uint32_t node01 = grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0});
+      uint32_t node10 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0});
+      uint32_t node11 =
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0});
 
-        // Grid-aligned constraints
-        if (i < (grid.width - 1)) {
-            this->_distanceConstraints.push_back(createDistanceConstraint(
-                this->_constraintId++,
-                this->_nodes[node00],
-                this->_nodes[node10],
-                w));
-        }
+      // Grid-aligned constraints
+      if (i < (grid.width - 1)) {
+        this->_distanceConstraints.push_back(createDistanceConstraint(
+            this->_constraintId++,
+            this->_nodes[node00],
+            this->_nodes[node10],
+            w));
+      }
 
-        if (j < (grid.height - 1)) {
-            this->_distanceConstraints.push_back(createDistanceConstraint(
-                this->_constraintId++,
-                this->_nodes[node00],
-                this->_nodes[node01],
-                w));
-        }
+      if (j < (grid.height - 1)) {
+        this->_distanceConstraints.push_back(createDistanceConstraint(
+            this->_constraintId++,
+            this->_nodes[node00],
+            this->_nodes[node01],
+            w));
+      }
 
-        // Long diagonal constraints
-        if (i < (grid.width - 1) && j < (grid.height - 1)) {
-            this->_distanceConstraints.push_back(createDistanceConstraint(
-                this->_constraintId++,
-                this->_nodes[node00],
-                this->_nodes[node11],
-                w));
-        }
+      // Long diagonal constraints
+      if (i < (grid.width - 1) && j < (grid.height - 1)) {
+        this->_distanceConstraints.push_back(createDistanceConstraint(
+            this->_constraintId++,
+            this->_nodes[node00],
+            this->_nodes[node11],
+            w));
+      }
     }
   }
 
   // TODO: HARD-CODED FOR GRID SIZE
   // Add distance constraints in each grid cell
   this->_bendConstraints.reserve(
-      currentBendConstraintsCount +
-      2 * (grid.width - 1) * (grid.height - 1));
+      currentBendConstraintsCount + 2 * (grid.width - 1) * (grid.height - 1));
   for (uint32_t i = 0; i < grid.width; ++i) {
     for (uint32_t j = 0; j < grid.height; ++j) {
-        uint32_t node00 = grid.gridIdToNodeId(currentNodeCount, {i, j, 0});
-        uint32_t node01 = grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0});
-        uint32_t node10 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0});
-        uint32_t node11 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0});
+      uint32_t node00 = grid.gridIdToNodeId(currentNodeCount, {i, j, 0});
+      uint32_t node01 = grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0});
+      uint32_t node10 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0});
+      uint32_t node11 =
+          grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0});
 
-        // Diagonal constraints
-        if (i < (grid.width - 1) && j < (grid.height - 1)) {
-            this->_bendConstraints.push_back(createBendConstraint(
-                this->_constraintId++,
-                w,
-                this->_nodes[node00],
-                this->_nodes[node11],
-                this->_nodes[node10],
-                this->_nodes[node01]
-                ));
-        }
+      // Diagonal constraints
+      if (i < (grid.width - 1) && j < (grid.height - 1)) {
+        this->_bendConstraints.push_back(createBendConstraint(
+            this->_constraintId++,
+            w,
+            this->_nodes[node00],
+            this->_nodes[node11],
+            this->_nodes[node10],
+            this->_nodes[node01]));
+      }
 
-        if (i < (grid.width - 2) && j < (grid.height - 2)) {
-            uint32_t node02 = grid.gridIdToNodeId(currentNodeCount, {i, j + 2, 0});
-            uint32_t node12 = grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 2, 0});
-            uint32_t node20 = grid.gridIdToNodeId(currentNodeCount, {i + 2, j, 0});
-            uint32_t node21 = grid.gridIdToNodeId(currentNodeCount, {i + 2, j + 1, 0});
+      if (i < (grid.width - 2) && j < (grid.height - 2)) {
+        uint32_t node02 = grid.gridIdToNodeId(currentNodeCount, {i, j + 2, 0});
+        uint32_t node12 =
+            grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 2, 0});
+        uint32_t node20 = grid.gridIdToNodeId(currentNodeCount, {i + 2, j, 0});
+        uint32_t node21 =
+            grid.gridIdToNodeId(currentNodeCount, {i + 2, j + 1, 0});
 
-            //shared edge to the right of current grid square
-            this->_bendConstraints.push_back(createBendConstraint(
-                this->_constraintId++,
-                w,
-                this->_nodes[node10],
-                this->_nodes[node11],
-                this->_nodes[node00],
-                this->_nodes[node21]
-            ));
+        // shared edge to the right of current grid square
+        this->_bendConstraints.push_back(createBendConstraint(
+            this->_constraintId++,
+            w,
+            this->_nodes[node10],
+            this->_nodes[node11],
+            this->_nodes[node00],
+            this->_nodes[node21]));
 
-            //shared edge to the right of current grid square
-            this->_bendConstraints.push_back(createBendConstraint(
-                this->_constraintId++,
-                w,
-                this->_nodes[node01],
-                this->_nodes[node11],
-                this->_nodes[node00],
-                this->_nodes[node12]
-            ));
-        }
+        // shared edge to the right of current grid square
+        this->_bendConstraints.push_back(createBendConstraint(
+            this->_constraintId++,
+            w,
+            this->_nodes[node01],
+            this->_nodes[node11],
+            this->_nodes[node00],
+            this->_nodes[node12]));
+      }
     }
   }
 
-  this->_triangles.reserve(
-      currentTriCount + (2 * grid.width * grid.height));
+  this->_triangles.reserve(currentTriCount + (2 * grid.width * grid.height));
   for (uint32_t i = 0; i < grid.width - 1; ++i) {
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
       this->_triangles.push_back(

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -114,12 +114,26 @@ void Solver::createTetBox(
             this->_nodes[node001],
             this->_nodes[node011],
             this->_nodes[node111]));
+        this->_volumeConstraints.push_back(createVolumeConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node001],
+            this->_nodes[node011],
+            this->_nodes[node111]));
         this->_tets.push_back(
             {{this->_nodes[node000].id,
               this->_nodes[node001].id,
               this->_nodes[node011].id,
               this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node010],
+            this->_nodes[node011],
+            this->_nodes[node111]));
+        this->_volumeConstraints.push_back(createVolumeConstraint(
             this->_constraintId++,
             stiffness,
             this->_nodes[node000],
@@ -138,12 +152,26 @@ void Solver::createTetBox(
             this->_nodes[node001],
             this->_nodes[node101],
             this->_nodes[node111]));
+        this->_volumeConstraints.push_back(createVolumeConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node001],
+            this->_nodes[node101],
+            this->_nodes[node111]));
         this->_tets.push_back(
             {{this->_nodes[node000].id,
               this->_nodes[node001].id,
               this->_nodes[node101].id,
               this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node100],
+            this->_nodes[node101],
+            this->_nodes[node111]));
+        this->_volumeConstraints.push_back(createVolumeConstraint(
             this->_constraintId++,
             stiffness,
             this->_nodes[node000],
@@ -162,12 +190,26 @@ void Solver::createTetBox(
             this->_nodes[node010],
             this->_nodes[node110],
             this->_nodes[node111]));
+        this->_volumeConstraints.push_back(createVolumeConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node010],
+            this->_nodes[node110],
+            this->_nodes[node111]));
         this->_tets.push_back(
             {{this->_nodes[node000].id,
               this->_nodes[node010].id,
               this->_nodes[node110].id,
               this->_nodes[node111].id}});
         this->_tetConstraints.push_back(createTetrahedralConstraint(
+            this->_constraintId++,
+            stiffness,
+            this->_nodes[node000],
+            this->_nodes[node100],
+            this->_nodes[node110],
+            this->_nodes[node111]));
+        this->_volumeConstraints.push_back(createVolumeConstraint(
             this->_constraintId++,
             stiffness,
             this->_nodes[node000],
@@ -192,13 +234,13 @@ void Solver::createTetBox(
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0})});
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}),
@@ -230,17 +272,17 @@ void Solver::createTetBox(
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k}),
-           grid.gridIdToNodeId(
-               currentNodeCount,
-               {i + 1, grid.height - 1, k + 1})});
-
-      this->_triangles.push_back(
-          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
            grid.gridIdToNodeId(
                currentNodeCount,
                {i + 1, grid.height - 1, k + 1}),
-           grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1})});
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k})});
+
+      this->_triangles.push_back(
+          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, grid.height - 1, k + 1})});
     }
   }
 
@@ -248,13 +290,13 @@ void Solver::createTetBox(
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1})});
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1})});
+           grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}),
@@ -405,13 +447,13 @@ void Solver::createBox(
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0})});
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, grid.depth - 1}),
@@ -443,18 +485,17 @@ void Solver::createBox(
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k}),
-           grid.gridIdToNodeId(
-               currentNodeCount,
-               {i + 1, grid.height - 1, k + 1})});
-
-      this->_triangles.push_back(
-          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
            grid.gridIdToNodeId(
                currentNodeCount,
                {i + 1, grid.height - 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, grid.height - 1, k})});
 
-           grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1})});
+      this->_triangles.push_back(
+          {grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k}),
+           grid.gridIdToNodeId(currentNodeCount, {i, grid.height - 1, k + 1}),
+           grid.gridIdToNodeId(
+               currentNodeCount,
+               {i + 1, grid.height - 1, k + 1})});
     }
   }
 
@@ -462,13 +503,13 @@ void Solver::createBox(
     for (uint32_t k = 0; k < grid.depth - 1; ++k) {
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1})});
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {0, j, k}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1}),
-           grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1})});
+           grid.gridIdToNodeId(currentNodeCount, {0, j, k + 1}),
+           grid.gridIdToNodeId(currentNodeCount, {0, j + 1, k + 1})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {grid.width - 1, j, k}),
@@ -522,7 +563,7 @@ void Solver::createSheet(
     float scale,
     float mass,
     float stiffness) {
-  Grid grid{16, 16, 1};
+  Grid grid{4, 4, 1};
 
   size_t currentNodeCount = this->_nodes.size();
   size_t currentDistConstraintsCount = this->_distanceConstraints.size();
@@ -605,13 +646,13 @@ void Solver::createSheet(
     for (uint32_t j = 0; j < grid.height - 1; ++j) {
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j, 0})});
 
       this->_triangles.push_back(
           {grid.gridIdToNodeId(currentNodeCount, {i, j, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0}),
-           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0})});
+           grid.gridIdToNodeId(currentNodeCount, {i, j + 1, 0}),
+           grid.gridIdToNodeId(currentNodeCount, {i + 1, j + 1, 0})});
     }
   }
 

--- a/Src/PrimitiveUtilities.cpp
+++ b/Src/PrimitiveUtilities.cpp
@@ -75,10 +75,9 @@ void Solver::createTetBox(
         node.radius = 0.5f * scale;
         node.invMass = 1.0f / mass;
 
-        if (hinged && i == 0) {//} && j == 0) {
+        if (hinged && i == 0) { //} && j == 0) {
           this->_positionConstraints.push_back(
-              createPositionConstraint(this->_constraintId++, node,
-              stiffness));
+              createPositionConstraint(this->_constraintId++, node, stiffness));
         }
       }
     }
@@ -558,7 +557,7 @@ void Solver::createSheet(
     float scale,
     float mass,
     float stiffness) {
-  Grid grid{12, 12, 1};
+  Grid grid{40, 40, 1};
 
   size_t currentNodeCount = this->_nodes.size();
   size_t currentDistConstraintsCount = this->_distanceConstraints.size();
@@ -583,7 +582,7 @@ void Solver::createSheet(
       node.radius = 0.5f * scale;
       node.invMass = 1.0f / mass;
 
-      if (i == 0 || i == (grid.width - 1)) {
+      if (i == 0 || i == (grid.width - 1) || j == 0 || j == (grid.height - 1)) {
         this->_positionConstraints.push_back(
             createPositionConstraint(this->_constraintId++, node, stiffness));
       }

--- a/Src/ShapeMatchingConstraint.cpp
+++ b/Src/ShapeMatchingConstraint.cpp
@@ -72,7 +72,8 @@ void ShapeMatchingConstraint::projectToAuxiliaryVariable(
       this->_currentPositions,
       false);
   Eigen::Matrix3f R = T.block(0, 0, 3, 3);
-  Eigen::Vector3f t(centerOfMass.x, centerOfMass.y, centerOfMass.z);//T.block(0, 3, 3, 1);
+  Eigen::Vector3f t(centerOfMass.x, centerOfMass.y, centerOfMass.z);
+  t += T.block(0, 3, 3, 1);
 
   this->_projectedPositions.noalias() =
       (R * this->_materialCoordinates).colwise() + t;

--- a/Src/ShapeMatchingConstraint.cpp
+++ b/Src/ShapeMatchingConstraint.cpp
@@ -1,0 +1,69 @@
+#include "ShapeMatchingConstraint.h"
+
+#include <Eigen/Geometry>
+
+namespace Pies {
+ShapeMatchingConstraint::ShapeMatchingConstraint(
+    const std::vector<uint32_t>& indices,
+    const std::vector<glm::vec3>& materialCoordinates,
+    float w)
+    : _nodeIndices(indices),
+      _currentPositions(3, materialCoordinates.size()),
+      _materialCoordinates(3, materialCoordinates.size()),
+      _projectedPositions(3, materialCoordinates.size()),
+      _w(w) {
+  size_t vertexCount = materialCoordinates.size();
+
+  for (size_t i = 0; i < this->_materialCoordinates.size(); ++i) {
+    const glm::vec3& coordinate = materialCoordinates[i];
+    this->_materialCoordinates.coeffRef(0, i) = coordinate.x;
+    this->_materialCoordinates.coeffRef(1, i) = coordinate.y;
+    this->_materialCoordinates.coeffRef(2, i) = coordinate.z;
+  }
+}
+
+void ShapeMatchingConstraint::setupGlobalStiffnessMatrix(
+    Eigen::SparseMatrix<float>& systemMatrix) const {
+  // Assumes A and B are Identity.
+  for (uint32_t nodeId : this->_nodeIndices) {
+    systemMatrix.coeffRef(nodeId, nodeId) += this->_w;
+  }
+}
+
+void ShapeMatchingConstraint::setupGlobalForceVector(
+    Eigen::MatrixXf& forceVector) const {
+  // Assumes A and B are Identity.
+  for (uint32_t i = 0; i < this->_nodeIndices.size(); ++i) {
+    uint32_t nodeId = this->_nodeIndices[i];
+
+    forceVector.coeffRef(nodeId, 0) +=
+        this->_w * this->_projectedPositions.coeff(i, 0);
+    forceVector.coeffRef(nodeId, 1) +=
+        this->_w * this->_projectedPositions.coeff(i, 1);
+    forceVector.coeffRef(nodeId, 2) +=
+        this->_w * this->_projectedPositions.coeff(i, 2);
+  }
+}
+
+void ShapeMatchingConstraint::projectToAuxiliaryVariable(
+    const std::vector<Node>& nodes) {
+  for (uint32_t i = 0; i < this->_nodeIndices.size(); ++i) {
+    uint32_t nodeId = this->_nodeIndices[i];
+    const glm::vec3& currentPosition = nodes[nodeId].position;
+    this->_currentPositions.coeffRef(0, i) = currentPosition.x;
+    this->_currentPositions.coeffRef(1, i) = currentPosition.y;
+    this->_currentPositions.coeffRef(2, i) = currentPosition.z;
+  }
+
+  Eigen::MatrixXf T = Eigen::umeyama(
+      this->_materialCoordinates,
+      this->_currentPositions,
+      false);
+  Eigen::Matrix3f R = T.block(0, 0, 3, 3);
+  Eigen::Vector3f t = T.block(0, 3, 3, 1);
+
+  // TODO: Check that this is doing column-wise addition of translation
+  // as intended.
+  this->_projectedPositions = R * this->_materialCoordinates + t;
+}
+} // namespace Pies

--- a/Src/ShapeMatchingConstraint.cpp
+++ b/Src/ShapeMatchingConstraint.cpp
@@ -14,7 +14,7 @@ ShapeMatchingConstraint::ShapeMatchingConstraint(
       _w(w) {
   size_t vertexCount = materialCoordinates.size();
 
-  for (size_t i = 0; i < this->_materialCoordinates.size(); ++i) {
+  for (size_t i = 0; i < materialCoordinates.size(); ++i) {
     const glm::vec3& coordinate = materialCoordinates[i];
     this->_materialCoordinates.coeffRef(0, i) = coordinate.x;
     this->_materialCoordinates.coeffRef(1, i) = coordinate.y;
@@ -37,11 +37,11 @@ void ShapeMatchingConstraint::setupGlobalForceVector(
     uint32_t nodeId = this->_nodeIndices[i];
 
     forceVector.coeffRef(nodeId, 0) +=
-        this->_w * this->_projectedPositions.coeff(i, 0);
+        this->_w * this->_projectedPositions.coeff(0, i);
     forceVector.coeffRef(nodeId, 1) +=
-        this->_w * this->_projectedPositions.coeff(i, 1);
+        this->_w * this->_projectedPositions.coeff(1, i);
     forceVector.coeffRef(nodeId, 2) +=
-        this->_w * this->_projectedPositions.coeff(i, 2);
+        this->_w * this->_projectedPositions.coeff(2, i);
   }
 }
 
@@ -55,15 +55,13 @@ void ShapeMatchingConstraint::projectToAuxiliaryVariable(
     this->_currentPositions.coeffRef(2, i) = currentPosition.z;
   }
 
-  Eigen::MatrixXf T = Eigen::umeyama(
+  Eigen::Matrix4f T = Eigen::umeyama(
       this->_materialCoordinates,
       this->_currentPositions,
       false);
   Eigen::Matrix3f R = T.block(0, 0, 3, 3);
   Eigen::Vector3f t = T.block(0, 3, 3, 1);
 
-  // TODO: Check that this is doing column-wise addition of translation
-  // as intended.
-  this->_projectedPositions = R * this->_materialCoordinates + t;
+  this->_projectedPositions = (R * this->_materialCoordinates).colwise() + t;
 }
 } // namespace Pies

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -158,7 +158,8 @@ void Solver::tickPBD(float /*timestep*/) {
 void Solver::tickPD(float /*timestep*/) {
   uint32_t nodeCount = static_cast<uint32_t>(this->_nodes.size());
 
-  // TODO: Remove time substeps for PD solver
+  // this->_volumeConstraints.clear();
+
   float h = this->_options.fixedTimestepSize / this->_options.timeSubsteps;
   float h2 = h * h;
 

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -823,41 +823,25 @@ void Solver::_parallelPointTriangleCollisions() {
           const Node& nodeD = nodes[pOtherTri->nodeIds[2]];
 
           // Point-triangle collisions
+          for (uint32_t i = 0; i < 3; ++i) {
+            const Node& nodeA = nodes[tri.nodeIds[i]];
 
-          // bool anyVerticesColliding = false;
-          // for (uint32_t i = 0; i < 3; ++i) {
-          //   const Node& nodeA = nodes[tri.nodeIds[i]];
+            std::optional<float> optT = CollisionDetection::pointTriangleCCD(
+                nodeA.prevPosition - nodeB.prevPosition,
+                nodeC.prevPosition - nodeB.prevPosition,
+                nodeD.prevPosition - nodeB.prevPosition,
+                nodeA.position - nodeB.position,
+                nodeC.position - nodeB.position,
+                nodeD.position - nodeB.position);
 
-          //   std::optional<float> optT = CollisionDetection::pointTriangleCCD(
-          //       nodeA.prevPosition - nodeB.prevPosition,
-          //       nodeC.prevPosition - nodeB.prevPosition,
-          //       nodeD.prevPosition - nodeB.prevPosition,
-          //       nodeA.position - nodeB.position,
-          //       nodeC.position - nodeB.position,
-          //       nodeD.position - nodeB.position);
+            if (!optT) {
+              // CCD did not find intersection
+              continue;
+            }
 
-          //   if (optT) {
-          //     // CCD found an intersection
-          //     anyVerticesColliding = true;
-          //     break;
-          //   }
-          // }
+            data.triCollisions.emplace_back(nodeA, nodeB, nodeC, nodeD);
+          }
 
-          // // TODO: Maybe collision constraints should be added between specific
-          // // edge or point-tri pairs??
-          // if (anyVerticesColliding) {
-          //   // Point-Tri collisions
-          //   for (uint32_t i = 0; i < 3; ++i) {
-          //     const Node& a = nodes[tri.nodeIds[i]];
-
-          //     data.triCollisions.emplace_back(
-          //         a,
-          //         nodes[pOtherTri->nodeIds[0]],
-          //         nodes[pOtherTri->nodeIds[1]],
-          //         nodes[pOtherTri->nodeIds[2]]);
-          //   }
-
-            // Edge collisions
           // for (uint32_t i = 0; i < 3; ++i) {
           //   for (uint32_t j = 0; j < 3; ++j) {
           //     const Node& a = nodes[tri.nodeIds[i]];
@@ -882,28 +866,6 @@ void Solver::_parallelPointTriangleCollisions() {
           //     data.edgeCollisions.emplace_back(a, b, c, d);
           //   }
           // }
-          // }
-
-          for (uint32_t i = 0; i < 3; ++i) {
-            const Node& nodeA = nodes[tri.nodeIds[i]];
-
-            std::optional<float> optT = CollisionDetection::pointTriangleCCD(
-                nodeA.prevPosition - nodeB.prevPosition,
-                nodeC.prevPosition - nodeB.prevPosition,
-                nodeD.prevPosition - nodeB.prevPosition,
-                nodeA.position - nodeB.position,
-                nodeC.position - nodeB.position,
-                nodeD.position - nodeB.position);
-
-            if (!optT) {
-              // CCD did not find intersection
-              continue;
-            }
-
-            data.triCollisions.emplace_back(nodeA, nodeB, nodeC, nodeD);
-          }
-
-          // Edge-edge intersectinos
         }
       }
 

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -158,7 +158,8 @@ void Solver::tickPBD(float /*timestep*/) {
 void Solver::tickPD(float /*timestep*/) {
   uint32_t nodeCount = static_cast<uint32_t>(this->_nodes.size());
 
-  // this->_volumeConstraints.clear();
+  // TODO: REMOVE THIS LINE
+  this->_volumeConstraints.clear();
 
   float h = this->_options.fixedTimestepSize / this->_options.timeSubsteps;
   float h2 = h * h;

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -158,9 +158,6 @@ void Solver::tickPBD(float /*timestep*/) {
 void Solver::tickPD(float /*timestep*/) {
   uint32_t nodeCount = static_cast<uint32_t>(this->_nodes.size());
 
-  // TODO: REMOVE THIS LINE
-  this->_volumeConstraints.clear();
-
   float h = this->_options.fixedTimestepSize / this->_options.timeSubsteps;
   float h2 = h * h;
 

--- a/Src/Solver.cpp
+++ b/Src/Solver.cpp
@@ -178,6 +178,10 @@ void Solver::tickPD(float /*timestep*/) {
       constraint.setupGlobalStiffnessMatrix(this->_stiffnessMatrix);
     }
 
+    for (ShapeMatchingConstraint& constraint : this->_shapeConstraints) {
+      constraint.setupGlobalStiffnessMatrix(this->_stiffnessMatrix);
+    }
+
     // Perform Sparse Cholesky LLT factorization
     this->_pLltDecomp =
         std::make_unique<Eigen::SimplicialLLT<Eigen::SparseMatrix<float>>>(
@@ -224,6 +228,10 @@ void Solver::tickPD(float /*timestep*/) {
         constraint.projectToAuxiliaryVariable(this->_nodes);
       }
 
+      for (ShapeMatchingConstraint& constraint : this->_shapeConstraints) {
+        constraint.projectToAuxiliaryVariable(this->_nodes);
+      }
+
       for (PositionConstraint& constraint : this->_positionConstraints) {
         constraint.setupGlobalForceVector(this->_forceVector);
       }
@@ -233,6 +241,10 @@ void Solver::tickPD(float /*timestep*/) {
       }
 
       for (TetrahedralConstraint& constraint : this->_tetConstraints) {
+        constraint.setupGlobalForceVector(this->_forceVector);
+      }
+
+      for (ShapeMatchingConstraint& constraint : this->_shapeConstraints) {
         constraint.setupGlobalForceVector(this->_forceVector);
       }
 
@@ -325,6 +337,7 @@ void Solver::clear() {
   this->_nodes.clear();
   this->_distanceConstraints.clear();
   this->_tetConstraints.clear();
+  this->_shapeConstraints.clear();
   this->_tets.clear();
   this->_positionConstraints.clear();
   this->_vertices.clear();


### PR DESCRIPTION
This PR is a large overhaul of the solver and also adds key features. Main changes:
- Adds a continuous triangle-triangle collision detection to generate point-triangle collision constraints. The algorithm solves for the roots of a cubic expression formulated from the trajectories of the four points over the interval. The spatial hash is used as a crude broad-phase, though we may find soon that we need a BVH.
- Collision detection is moved outside the solver loop as recommended in PBD literature.
- Added post-solver collision stabilization iterations - this is essentially PBD collision resolution with a stiffness of 1. This step should only be a small cleanup since the PD solver attempts to resolve collisions itself. The collision stabilization simply helps to further enforce non-penetration, though in insidious cases it could fail as well. Care is taken to _not_ introduce any extra velocity during this step. 
- Changed A and B in translation-invariant PD constraints (e.g., distance, tetrahedral strain, etc.) so that the constraint projection and energy potential are in terms of _differential coordinates_. Previously A and B were always identity matrices. This change dramatically speeds up convergence and stability. Collision constraints actually _need_ differential coordinates, which motivated this change.
- As part of the previous change, I also changed (and simplified) the tetrahedral strain constraint to use the formulation in the PD paper - previously we were using a formulation from PBD literature. However, this change now requires an SVD of a 3x3 matrix when projecting tetrahedral constraints - we will need to keep an eye out for if this becomes a performance concern.
- A WIP shape-matching constraint has also been added in this PR. From initial experimentation, I am not sure how useful it will be for us. It is currently buggy, but I don't think that is worth fixing for the time being.

Remaining tasks:
- [x] Integrate edge-edge collision resolution into the triangle CCD
- [x] Integrate edge-edge collision detection if needed (though this seems like it might be expensive).

Note: Edge collision is implemented but is currently disabled. This seems mostly okay for now for meshes that are properly tetrahedralized and don't have skinny sharp corners - ideally we should revisit this at some point.